### PR TITLE
[WIP] Implement ZMP-CoM gain scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ make
 ```
 Notice: `sudo` is not necessary if you specify the `CMAKE_INSTALL_PREFIX`. In this case it is necessary to add in the `.bashrc` or `.bash_profile` the following lines:
 ```sh
-export walking-controllers_DIR=/path/where/you/installed/
-export PATH=$PATH:$walking-controllers_DIR/bin
-export YARP_DATA_DIRS=${YARP_DATA_DIRS}:walking-controllers_DIR/share/yarp
+export WalkingControllers_INSTALL_DIR=/path/where/you/installed/
+export PATH=$PATH:$WalkingControllers_INSTALL_DIR/bin
+export YARP_DATA_DIRS=$YARP_DATA_DIRS:$WalkingControllers_INSTALL_DIR/share/yarp
 ```
 
 # :computer: How to run the simulation

--- a/app/robots/iCubGazeboV2_5/zmpControllerParams.ini
+++ b/app/robots/iCubGazeboV2_5/zmpControllerParams.ini
@@ -1,2 +1,11 @@
-kZMP                    1.5
-kCoM                    6.0
+# remove the following line if you do not want the gain scheduling
+useGainScheduling      1
+
+smoothingTime          1.0
+
+# if the gain scheduling is off only k*_walking parameters are used
+kZMP_walking           1.5
+kCoM_walking           6.0
+
+kZMP_stance            1.5
+kCoM_stance            6.0

--- a/app/robots/iCubGenova02/zmpControllerParams.ini
+++ b/app/robots/iCubGenova02/zmpControllerParams.ini
@@ -1,2 +1,11 @@
-kZMP                    1.5
-kCoM                    6.0
+# remove the following line if you do not want the gain scheduling
+useGainScheduling      1
+
+smoothingTime          1.0
+
+# if the gain scheduling is off only k*_walking parameters are used
+kZMP_walking           1.5
+kCoM_walking           6.0
+
+kZMP_stance            1.5
+kCoM_stance            6.0

--- a/app/robots/iCubGenova04/pidParams.ini
+++ b/app/robots/iCubGenova04/pidParams.ini
@@ -10,7 +10,7 @@
 #    -the field smoothingTime which defines the smoothing time with which the PIDs will be changed (OPTIONAL, default 1.0)
 
 # if 0 only the default group will be taken into consideration
-useGainScheduling           1
+useGainScheduling           0
 firmwareDelay               0.01
 smoothingTime               0.05
 

--- a/app/robots/iCubGenova04/plannerParams.ini
+++ b/app/robots/iCubGenova04/plannerParams.ini
@@ -26,7 +26,7 @@ minStepDuration         0.8
 #Width
 nominalWidth            0.16
 #Height
-stepHeight              0.03
+stepHeight              0.025
 stepLandingVelocity     0.0
 footApexTime            0.8
 comHeightDelta          0.01

--- a/app/robots/iCubGenova04/plannerParams.ini
+++ b/app/robots/iCubGenova04/plannerParams.ini
@@ -20,7 +20,7 @@ maxAngleVariation       10.0
 minAngleVariation       8.0
 #Timings
 maxStepDuration         1.0
-minStepDuration         0.5
+minStepDuration         0.8
 
 ##Nominal Values
 #Width
@@ -31,7 +31,7 @@ stepLandingVelocity     0.0
 footApexTime            0.8
 comHeightDelta          0.01
 #Timings
-nominalDuration         0.75
+nominalDuration         0.9
 lastStepSwitchTime      0.8
 switchOverSwingRatio    0.7
 
@@ -43,8 +43,7 @@ rightZMPDelta          (0.03 0.005)
 mergePointRatio         0.4
 
 # pitch delta
-pitchDelta		-3.0	
-# pitchDelta		0.0
+pitchDelta		0.0
 
 ##Should be the first step with the left foot?
 swingLeft               1

--- a/app/robots/iCubGenova04/zmpControllerParams.ini
+++ b/app/robots/iCubGenova04/zmpControllerParams.ini
@@ -4,7 +4,7 @@ useGainScheduling      1
 smoothingTime          0.1
 
 # if the gain scheduling is off only k*_walking parameters are used
-kZMP_walking           3.0
+kZMP_walking           3.5
 kCoM_walking           10.0
 
 kZMP_stance            0.9

--- a/app/robots/iCubGenova04/zmpControllerParams.ini
+++ b/app/robots/iCubGenova04/zmpControllerParams.ini
@@ -1,10 +1,18 @@
- #kZMP                    2.0
-#kZMP                    1.9	
-#kCoM                    8.0
+# remove the following line if you do not want the gain scheduling
+useGainScheduling      1
 
-#kZMP                    1.0
-#kCoM                    8.0
+smoothingTime          0.1
 
-kZMP                    3.25
-kCoM                    10.0
+# if the gain scheduling is off only k*_walking parameters are used
+kZMP_walking           3.0
+kCoM_walking           10.0
 
+kZMP_stance            0.9
+kCoM_stance            6.0
+
+# old parameters
+#kZMP                    2.0 low velocity reactive
+#kZMP                    1.9 low velocity MPC
+
+#kCoM                    10.0 low velocity reactive
+#kCoM                    8.0 low velocity MPC

--- a/app/robots/icubGazeboSim/zmpControllerParams.ini
+++ b/app/robots/icubGazeboSim/zmpControllerParams.ini
@@ -1,2 +1,11 @@
-kZMP                    1.7
-kCoM                    5.5
+# remove the following line if you do not want the gain scheduling
+useGainScheduling      1
+
+smoothingTime          0.1
+
+# if the gain scheduling is off only k*_walking parameters are used
+kZMP_walking            1.7
+kCoM_walking            5.5
+
+kZMP_stance             1.2
+kCoM_stance             5.0

--- a/modules/Walking_module/include/WalkingZMPController.hpp
+++ b/modules/Walking_module/include/WalkingZMPController.hpp
@@ -17,6 +17,7 @@
 
 // iCub-ctrl
 #include <iCub/ctrl/pids.h>
+#include <iCub/ctrl/minJerkCtrl.h>
 
 // iDynTree
 #include <iDynTree/Core/VectorFixSize.h>
@@ -29,8 +30,14 @@
  */
 class WalkingZMPController
 {
-    double m_kZMP; /**< Controller gain. */
-    double m_kCoM; /**< Controller gain. */
+    double m_kZMP; /**< CoM controller gain. */
+    double m_kCoM; /**< ZMP controller gain. */
+
+    double m_kCoMWalking; /**< Desired CoM controller gain during the walking phase. */
+    double m_kZMPWalking; /**< Desired ZMP controller gain during the walking phase. */
+
+    double m_kCoMStance; /**< Desired CoM controller gain during the stance phase. */
+    double m_kZMPStance; /**< Desired ZMP controller gain during the stance phase. */
 
     bool m_controlEvaluated; /**< True if the control output was correctly evaluated. */
 
@@ -49,6 +56,12 @@ class WalkingZMPController
      */
     std::unique_ptr<iCub::ctrl::Integrator> m_velocityIntegral{nullptr};
 
+    bool m_useGainScheduling; /**< True of the gain scheduling is used.*/
+    std::unique_ptr<iCub::ctrl::minJerkTrajGen> m_kZMPSmoother; /**< Minimum jerk trajectory for the
+                                                                   ZMP gain. */
+    std::unique_ptr<iCub::ctrl::minJerkTrajGen> m_kCoMSmoother; /**< Minimum jerk trajectory for the
+                                                                   CoM gain. */
+
 public:
 
     /**
@@ -65,6 +78,12 @@ public:
      */
     void setFeedback(const iDynTree::Vector2& zmpFeedback,
                      const iDynTree::Position& comFeedback);
+
+    /**
+     * set the phase (Walking or stance)
+     * @param isStancePhase true if the current phase is the stance phase.
+     */
+    void setPhase(const bool& isStancePhase);
 
     /**
      * Set the desired reference signals.


### PR DESCRIPTION
This branch implements the gain scheduling for the ZMP-CoM controller. It allows reducing the oscillations during the stance phase.

## TODO
- [x] Implement ZMP-CoM gain scheduling 
- [ ] Port the software to `YARP 3`
- [ ] Test the controller on iCubGazeboV2_5
- [x] Test the controller on `iCubGenova04`
- [ ] Test the controller on `iCubGenova02`