### PR TITLE
Fix the bug related to the resetting of the hand retargeting client 

### DIFF
--- a/app/robots/iCubGazeboV2_5/dcm_walking/hand_retargeting/handRetargeting.ini
+++ b/app/robots/iCubGazeboV2_5/dcm_walking/hand_retargeting/handRetargeting.ini
@@ -2,3 +2,5 @@ left_hand_transform_port_name     /leftHandDesiredPose:i
 right_hand_transform_port_name    /rightHandDesiredPose:i
 
 smoothing_time       0.1
+
+robot_orientation_port_name     /torsoYaw:o

--- a/app/robots/iCubGazeboV2_5/dcm_walking_retargeting.ini
+++ b/app/robots/iCubGazeboV2_5/dcm_walking_retargeting.ini
@@ -19,7 +19,7 @@ com_height              0.53
 # sampling time
 sampling_time           0.01
 # enable hand retargeting
-enable_hand_retargeting 1
+use_hand_retargeting    1
 # enable the virtualizer
 use_virtualizer         1
 

--- a/app/robots/iCubGenova04/dcm_walking/hand_retargeting/qpInverseKinematics.ini
+++ b/app/robots/iCubGenova04/dcm_walking/hand_retargeting/qpInverseKinematics.ini
@@ -1,5 +1,3 @@
-enable_hand_retargeting                  1
-
 # CoM
 use_com_as_constraint             1
 # comWeightTriplets              ((0,0,100), (1,1,100), (2,2,100))

--- a/modules/Walking_module/src/WalkingModule.cpp
+++ b/modules/Walking_module/src/WalkingModule.cpp
@@ -486,6 +486,18 @@ bool WalkingModule::updateModule()
             m_stableDCMModel->reset(m_DCMPositionDesired.front());
 
             // reset the retargeting
+            if(!m_robotControlHelper->getFeedbacks(10))
+            {
+                yError() << "[WalkingModule::updateModule] Unable to get the feedback.";
+                return false;
+            }
+
+            if(!updateFKSolver())
+            {
+                yError() << "[WalkingModule::updateModule] Unable to update the FK solver.";
+                return false;
+            }
+
             m_retargetingClient->reset(m_FKSolver->getHeadToWorldTransform().inverse()
                                        * m_FKSolver->getLeftHandToWorldTransform(),
                                        m_FKSolver->getHeadToWorldTransform().inverse()

--- a/modules/Walking_module/src/WalkingQPInverseKinematics.cpp
+++ b/modules/Walking_module/src/WalkingQPInverseKinematics.cpp
@@ -38,7 +38,7 @@ bool WalkingQPIK::initialize(const yarp::os::Searchable &config,
     }
 
     m_useCoMAsConstraint = config.check("use_com_as_constraint", yarp::os::Value(false)).asBool();
-    m_enableHandRetargeting = config.check("enable_hand_retargeting", yarp::os::Value(false)).asBool();
+    m_enableHandRetargeting = config.check("use_hand_retargeting", yarp::os::Value(false)).asBool();
     m_useJointsLimitsConstraint = config.check("use_joint_limits_constraint", yarp::os::Value(false)).asBool();
 
     // TODO in the future the number of constraints should be added inside


### PR DESCRIPTION
This PR:
* fixes a bug related to the resetting of the `m_retargetingClient`  e238df4
* fixes the configuration files for `iCubGenova04` and `iCubGazeboV2_5`