### PR TITLE
Avoid error on missing operator+ when summing hessian components.

### DIFF
--- a/src/WholeBodyControllers/src/QPInverseKinematics.cpp
+++ b/src/WholeBodyControllers/src/QPInverseKinematics.cpp
@@ -511,8 +511,8 @@ void WalkingQPIK::evaluateHessianMatrix()
     else
     {
         // think about the possibility to project in the null space the joint regularization
-        hessianDense += iDynTree::toEigen(m_jointRegularizationHessian)
-            + iDynTree::toEigen(m_leftHandJacobian).transpose()
+        hessianDense += iDynTree::toEigen(m_jointRegularizationHessian);
+        hessianDense += iDynTree::toEigen(m_leftHandJacobian).transpose()
             * iDynTree::toEigen(m_handWeightSmoother->getPos()).asDiagonal()
             * iDynTree::toEigen(m_leftHandJacobian)
             + iDynTree::toEigen(m_rightHandJacobian).transpose()


### PR DESCRIPTION
I am currently having this error when compiling both on ``master`` and ``devel``:
```
/home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/QPInverseKinematics.cpp: In member function ‘void WalkingControllers::WalkingQPIK::evaluateHessianMatrix()’:
/home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/QPInverseKinematics.cpp:515:13: error: no match for ‘operator+’ (operand types are ‘Eigen::Map<Eigen::SparseMatrix<double, 0> >’ and ‘const Eigen::Product<Eigen::Product<Eigen::Transpose<Eigen::Map<Eigen::Matrix<double, -1, -1, 1> > >, Eigen::DiagonalWrapper<const Eigen::Map<const Eigen::Matrix<double, -1, 1> > >, 1>, Eigen::Map<Eigen::Matrix<double, -1, -1, 1> >, 0>’)
             + iDynTree::toEigen(m_leftHandJacobian).transpose()
             ^
In file included from /usr/include/eigen3/Eigen/src/SparseCore/SparseMatrixBase.h:152:0,
                 from /usr/include/eigen3/Eigen/SparseCore:37,
                 from /home/sdafarra/Software/robotology-superbuild/build/install/include/iDynTree/Core/EigenSparseHelpers.h:14,
                 from /home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/QPInverseKinematics.cpp:18:
/usr/include/eigen3/Eigen/src/plugins/CommonCwiseBinaryOps.h:27:129: note: candidate: template<class OtherDerived> const Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<typename Eigen::internal::traits<T>::Scalar>, const Derived, const OtherDerived> Eigen::SparseMatrixBase<Derived>::operator+(const Eigen::SparseMatrixBase<OtherDerived>&) const [with OtherDerived = OtherDerived; Derived = Eigen::Map<Eigen::SparseMatrix<double, 0> >]
/usr/include/eigen3/Eigen/src/plugins/CommonCwiseBinaryOps.h:27:129: note:   template argument deduction/substitution failed:
/home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/QPInverseKinematics.cpp:517:51: note:   ‘const Eigen::Product<Eigen::Product<Eigen::Transpose<Eigen::Map<Eigen::Matrix<double, -1, -1, 1> > >, Eigen::DiagonalWrapper<const Eigen::Map<const Eigen::Matrix<double, -1, 1> > >, 1>, Eigen::Map<Eigen::Matrix<double, -1, -1, 1> >, 0>’ is not derived from ‘const Eigen::SparseMatrixBase<OtherDerived>’
             * iDynTree::toEigen(m_leftHandJacobian)
                                                   ^
In file included from /home/sdafarra/Software/robotology-superbuild/build/install/include/iCub/ctrl/math.h:42:0,
                 from /home/sdafarra/Software/robotology-superbuild/build/install/include/iCub/ctrl/filters.h:28,
                 from /home/sdafarra/Software/robotology-superbuild/build/install/include/iCub/ctrl/minJerkCtrl.h:31,
                 from /home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/include/WalkingControllers/WholeBodyControllers/QPInverseKinematics.h:24,
                 from /home/sdafarra/Software/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/QPInverseKinematics.cpp:26:
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:26:60: note: candidate: yarp::sig::Vector operator+(const Vector&, const double&)
 YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const double &s);
                                                            ^
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:26:60: note:   no known conversion for argument 1 from ‘Eigen::Map<Eigen::SparseMatrix<double, 0> >’ to ‘const Vector& {aka const yarp::sig::VectorOf<double>&}’
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:32:60: note: candidate: yarp::sig::Vector operator+(const double&, const Vector&)
 YARP_math_API yarp::sig::Vector operator+(const double &s, const yarp::sig::Vector &a);
                                                            ^
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:32:60: note:   no known conversion for argument 1 from ‘Eigen::Map<Eigen::SparseMatrix<double, 0> >’ to ‘const double&’
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:43:60: note: candidate: yarp::sig::Vector operator+(const Vector&, const Vector&)
 YARP_math_API yarp::sig::Vector operator+(const yarp::sig::Vector &a, const yarp::sig::Vector &b);
                                                            ^
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:43:60: note:   no known conversion for argument 1 from ‘Eigen::Map<Eigen::SparseMatrix<double, 0> >’ to ‘const Vector& {aka const yarp::sig::VectorOf<double>&}’
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:53:60: note: candidate: yarp::sig::Matrix operator+(const yarp::sig::Matrix&, const yarp::sig::Matrix&)
 YARP_math_API yarp::sig::Matrix operator+(const yarp::sig::Matrix &a, const yarp::sig::Matrix &b);
                                                            ^
/home/sdafarra/Software/robotology-superbuild/build/install/include/yarp/math/Math.h:53:60: note:   no known conversion for argument 1 from ‘Eigen::Map<Eigen::SparseMatrix<double, 0> >’ to ‘const yarp::sig::Matrix&’
src/WholeBodyControllers/CMakeFiles/WholeBodyControllers.dir/build.make:92: recipe for target 'src/WholeBodyControllers/CMakeFiles/WholeBodyControllers.dir/src/QPInverseKinematics.cpp.o' failed
make[5]: *** [src/WholeBodyControllers/CMakeFiles/WholeBodyControllers.dir/src/QPInverseKinematics.cpp.o] Error 1
CMakeFiles/Makefile2:627: recipe for target 'src/WholeBodyControllers/CMakeFiles/WholeBodyControllers.dir/all' failed
make[4]: *** [src/WholeBodyControllers/CMakeFiles/WholeBodyControllers.dir/all] Error 2
Makefile:146: recipe for target 'all' failed
make[3]: *** [all] Error 2
CMakeFiles/walking-controllers.dir/build.make:130: recipe for target 'robotology/walking-controllers/CMakeFiles/YCMStamp/walking-controllers-build' failed
make[2]: *** [robotology/walking-controllers/CMakeFiles/YCMStamp/walking-controllers-build] Error 2
CMakeFiles/Makefile2:2381: recipe for target 'CMakeFiles/walking-controllers.dir/all' failed
make[1]: *** [CMakeFiles/walking-controllers.dir/all] Error 2
Makefile:157: recipe for target 'all' failed
make: *** [all] Error 2
```

I don't know if it may be related to the ``Eigen`` version. But by simply splitting the sum, it disappears.
