### PR TITLE
Add workaround for issue with MSVC 2019 and Eigen 3.3

### DIFF
--- a/modules/Walking_module/CMakeLists.txt
+++ b/modules/Walking_module/CMakeLists.txt
@@ -78,6 +78,12 @@ yarp_add_idl(${EXE_TARGET_NAME}_THRIFT_GEN_FILES ${${EXE_TARGET_NAME}_THRIFT_HDR
 add_executable(${EXE_TARGET_NAME} ${${EXE_TARGET_NAME}_SRC} ${${EXE_TARGET_NAME}_HDR}
   ${${EXE_TARGET_NAME}_THRIFT_GEN_FILES})
 
+# Workaround for the bug in Eigen3 3.3 with MSVC
+# See https://github.com/robotology/walking-controllers/issues/47
+if (MSVC AND (${EIGEN3_VERSION} VERSION_LESS 3.4))
+  target_compile_definitions(${EXE_TARGET_NAME} PRIVATE WALKING_CONTROLLERS_EIGEN_3_3_WORKAROUND)
+endif()
+
 target_link_libraries(${EXE_TARGET_NAME}
   ${YARP_LIBRARIES}
   ${iDynTree_LIBRARIES}

--- a/modules/Walking_module/include/eigen_workaround/SparseCwiseUnaryOp.h
+++ b/modules/Walking_module/include/eigen_workaround/SparseCwiseUnaryOp.h
@@ -1,0 +1,170 @@
+// This file is part of Eigen, a lightweight C++ template library
+// for linear algebra.
+//
+// Copyright (C) 2008-2015 Gael Guennebaud <gael.guennebaud@inria.fr>
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Eigen/Core"
+
+#include <vector>
+#include <map>
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
+
+#include "Eigen/src/SparseCore/SparseUtil.h"
+#include "Eigen/src/SparseCore/SparseMatrixBase.h"
+#include "Eigen/src/SparseCore/SparseAssign.h"
+#include "Eigen/src/SparseCore/CompressedStorage.h"
+#include "Eigen/src/SparseCore/AmbiVector.h"
+#include "Eigen/src/SparseCore/SparseCompressedBase.h"
+#include "Eigen/src/SparseCore/SparseMatrix.h"
+#include "Eigen/src/SparseCore/SparseMap.h"
+#include "Eigen/src/SparseCore/MappedSparseMatrix.h"
+#include "Eigen/src/SparseCore/SparseVector.h"
+#include "Eigen/src/SparseCore/SparseRef.h"
+
+#ifndef EIGEN_SPARSE_CWISE_UNARY_OP_H
+#define EIGEN_SPARSE_CWISE_UNARY_OP_H
+
+
+namespace Eigen { 
+
+namespace internal {
+  
+template<typename UnaryOp, typename ArgType>
+struct unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>
+  : public evaluator_base<CwiseUnaryOp<UnaryOp,ArgType> >
+{
+  public:
+    typedef CwiseUnaryOp<UnaryOp, ArgType> XprType;
+
+    class InnerIterator;
+    
+    enum {
+      CoeffReadCost = evaluator<ArgType>::CoeffReadCost + functor_traits<UnaryOp>::Cost,
+      Flags = XprType::Flags
+    };
+    
+    explicit unary_evaluator(const XprType& op) : m_functor(op.functor()), m_argImpl(op.nestedExpression())
+    {
+      EIGEN_INTERNAL_CHECK_COST_VALUE(functor_traits<UnaryOp>::Cost);
+      EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
+    }
+    
+    inline Index nonZerosEstimate() const {
+      return m_argImpl.nonZerosEstimate();
+    }
+
+  protected:
+    typedef typename evaluator<ArgType>::InnerIterator        EvalIterator;
+    
+    const UnaryOp m_functor;
+    evaluator<ArgType> m_argImpl;
+};
+
+template<typename UnaryOp, typename ArgType>
+class unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>::InnerIterator
+    : public unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>::EvalIterator
+{
+  protected:  
+    typedef typename XprType::Scalar Scalar;
+    typedef typename unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>::EvalIterator Base;
+  public:
+
+    EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& unaryOp, Index outer)
+      : Base(unaryOp.m_argImpl,outer), m_functor(unaryOp.m_functor)
+    {}
+
+    EIGEN_STRONG_INLINE InnerIterator& operator++()
+    { Base::operator++(); return *this; }
+
+    EIGEN_STRONG_INLINE Scalar value() const { return m_functor(Base::value()); }
+
+  protected:
+    const UnaryOp m_functor;
+  private:
+    Scalar& valueRef();
+};
+
+template<typename ViewOp, typename ArgType>
+struct unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>
+  : public evaluator_base<CwiseUnaryView<ViewOp,ArgType> >
+{
+  public:
+    typedef CwiseUnaryView<ViewOp, ArgType> XprType;
+
+    class InnerIterator;
+    
+    enum {
+      CoeffReadCost = evaluator<ArgType>::CoeffReadCost + functor_traits<ViewOp>::Cost,
+      Flags = XprType::Flags
+    };
+    
+    explicit unary_evaluator(const XprType& op) : m_functor(op.functor()), m_argImpl(op.nestedExpression())
+    {
+      EIGEN_INTERNAL_CHECK_COST_VALUE(functor_traits<ViewOp>::Cost);
+      EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
+    }
+
+  protected:
+    typedef typename evaluator<ArgType>::InnerIterator        EvalIterator;
+    
+    const ViewOp m_functor;
+    evaluator<ArgType> m_argImpl;
+};
+
+template<typename ViewOp, typename ArgType>
+class unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::InnerIterator
+    : public unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::EvalIterator
+{
+    typedef typename XprType::Scalar Scalar;
+    typedef typename unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::EvalIterator Base;
+  public:
+
+    EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& unaryOp, Index outer)
+      : Base(unaryOp.m_argImpl,outer), m_functor(unaryOp.m_functor)
+    {}
+
+    EIGEN_STRONG_INLINE InnerIterator& operator++()
+    { Base::operator++(); return *this; }
+
+    EIGEN_STRONG_INLINE Scalar value() const { return m_functor(Base::value()); }
+    EIGEN_STRONG_INLINE Scalar& valueRef() { return m_functor(Base::valueRef()); }
+
+  protected:
+    const ViewOp m_functor;
+};
+
+} // end namespace internal
+
+template<typename Derived>
+EIGEN_STRONG_INLINE Derived&
+SparseMatrixBase<Derived>::operator*=(const Scalar& other)
+{
+  typedef typename internal::evaluator<Derived>::InnerIterator EvalIterator;
+  internal::evaluator<Derived> thisEval(derived());
+  for (Index j=0; j<outerSize(); ++j)
+    for (EvalIterator i(thisEval,j); i; ++i)
+      i.valueRef() *= other;
+  return derived();
+}
+
+template<typename Derived>
+EIGEN_STRONG_INLINE Derived&
+SparseMatrixBase<Derived>::operator/=(const Scalar& other)
+{
+  typedef typename internal::evaluator<Derived>::InnerIterator EvalIterator;
+  internal::evaluator<Derived> thisEval(derived());
+  for (Index j=0; j<outerSize(); ++j)
+    for (EvalIterator i(thisEval,j); i; ++i)
+      i.valueRef() /= other;
+  return derived();
+}
+
+} // end namespace Eigen
+
+#endif // EIGEN_SPARSE_CWISE_UNARY_OP_H

--- a/modules/Walking_module/src/WalkingQPInverseKinematics.cpp
+++ b/modules/Walking_module/src/WalkingQPInverseKinematics.cpp
@@ -6,6 +6,11 @@
  * @date 2018
  */
 
+// Workaround for Eigen 3.3 on MSVC
+#ifdef WALKING_CONTROLLERS_EIGEN_3_3_WORKAROUND
+#include <eigen_workaround/SparseCwiseUnaryOp.h>
+#endif
+
 // std
 #include <cmath>
 


### PR DESCRIPTION
This commit adds a workaround for issue https://github.com/robotology/walking-controllers/issues/47 .
In particular, it adds a vendored SparseCwiseUnaryOp.h file that has the correctly marked protected
members, via a backport of https://gitlab.com/libeigen/eigen/-/commit/f59bed7a133322955dac03f3654def706aff3ba6 .
As the include guards of the vendored SparseCwiseUnaryOp.h are the same of the one contained in Eigen, by including it first in the compilation unit that have this problem, we are able to make sure that the Eigen's version is ignored.
The workaround is used only if the compiler is `MSVC` and for Eigen 3.3, as the issue is expected to be solved in Eigen 3.4, and especially because the `SparseCwiseUnaryOp.h` will probably be quite different in Eigen 3.4, and so  it is possible that the vendored file is not compatible anymore with it. 