### PR TITLE
Add the possibility to set the last step dcm offset

### DIFF
--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -99,6 +99,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     double switchOverSwingRatio = config.check("switchOverSwingRatio",
                                                yarp::os::Value(0.4)).asDouble();
     double mergePointRatio = config.check("mergePointRatio", yarp::os::Value(0.5)).asDouble();
+    double lastStepDCMOffset = config.check("lastStepDCMOffset", yarp::os::Value(0.0)).asDouble();
 
     m_nominalWidth = config.check("nominalWidth", yarp::os::Value(0.04)).asDouble();
 
@@ -150,6 +151,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     m_dcmGenerator = m_trajectoryGenerator.addDCMTrajectoryGenerator();
     m_dcmGenerator->setFootOriginOffset(leftZMPDelta, rightZMPDelta);
     m_dcmGenerator->setOmega(sqrt(9.81/comHeight));
+    ok = ok && m_dcmGenerator->setLastStepDCMOffsetPercentage(lastStepDCMOffset);
 
     m_correctLeft = true;
 

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
@@ -39,6 +39,12 @@ switchOverSwingRatio    0.7
 leftZMPDelta           (0.03 -0.005)
 rightZMPDelta          (0.03 0.005)
 
+# Last Step DCM Offset
+# If it is 0.5 the final DCM will be in the middle of the two footsteps;
+# If it is 0 the DCM position coincides with the stance foot ZMP;
+# If it is 1 the DCM position coincides with the next foot ZMP position.
+lastStepDCMOffset      0.25
+
 #MergePoint
 mergePointRatio         0.4
 

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
@@ -39,6 +39,12 @@ switchOverSwingRatio    0.7
 leftZMPDelta           (0.03 -0.005)
 rightZMPDelta          (0.03 0.005)
 
+# Last Step DCM Offset
+# If it is 0.5 the final DCM will be in the middle of the two footsteps;
+# If it is 0 the DCM position coincides with the stance foot ZMP;
+# If it is 1 the DCM position coincides with the next foot ZMP position.
+lastStepDCMOffset      0.25
+
 #MergePoint
 mergePointRatio         0.4
 
@@ -52,4 +58,3 @@ startAlwaysSameFoot     1
 
 ##Remove this line if you don't want to use the minimum jerk trajectory in feet interpolation
 #useMinimumJerkFootTrajectory    1
-

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
@@ -39,6 +39,12 @@ switchOverSwingRatio    0.7
 leftZMPDelta           (0.03 -0.005)
 rightZMPDelta          (0.03 0.005)
 
+# Last Step DCM Offset
+# If it is 0.5 the final DCM will be in the middle of the two footsteps;
+# If it is 0 the DCM position coincides with the stance foot ZMP;
+# If it is 1 the DCM position coincides with the next foot ZMP position.
+lastStepDCMOffset      0.25
+
 #MergePoint
 mergePointRatio         0.4
 

--- a/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
@@ -38,6 +38,12 @@ switchOverSwingRatio    0.4
 leftZMPDelta            (0.02 0.0)
 rightZMPDelta           (0.02 0.0)
 
+# Last Step DCM Offset
+# If it is 0.5 the final DCM will be in the middle of the two footsteps;
+# If it is 0 the DCM position coincides with the stance foot ZMP;
+# If it is 1 the DCM position coincides with the next foot ZMP position.
+lastStepDCMOffset      0.25
+
 #MergePoint
 mergePointRatio         0.5
 


### PR DESCRIPTION
This feature was implemented in the unicycle planner in https://github.com/robotology/unicycle-footstep-planner/pull/28. With this PR it is now possible to change the DCM offset for the last step, and as a consequence improve the robustness of the walking