### PR TITLE
Fix missing include in TimeProfiler.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 
 ### Changed
-
+    - Add missing includes in `TimeProfiler` (https://github.com/robotology/walking-controllers/pull/60)
 
 ## [0.3.1] - 2020-03-18
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 ## MAIN project
 project(WalkingControllers
-  VERSION 0.3.1)
+  VERSION 0.3.2)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/src/TimeProfiler/src/TimeProfiler.cpp
+++ b/src/TimeProfiler/src/TimeProfiler.cpp
@@ -8,6 +8,7 @@
 
 #include <ctime>
 #include <iostream>
+#include <string>
 
 #include <WalkingControllers/TimeProfiler/TimeProfiler.h>
 


### PR DESCRIPTION
Related to https://github.com/robotology/robotology-superbuild/issues/366#issuecomment-600107376 and https://github.com/robotology/walking-controllers/issues/58#issuecomment-600107149