### PR TITLE
Fix the stance phase machinery 

### DIFF
--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -666,7 +666,9 @@ bool TrajectoryGenerator::getIsStancePhase(std::vector<bool>& isStancePhase)
         {
             // decreased the counter only if it is different from zero.
             // it is required to add a delay in the beginning of the stance phase
-            stancePhaseDelayCounter = stancePhaseDelayCounter == 0 ? 0 : stancePhaseDelayCounter--;
+            stancePhaseDelayCounter = (stancePhaseDelayCounter == 0)
+                                          ? 0
+                                          : (stancePhaseDelayCounter - 1);
 
             // the delay expired the robot can be considered stance
             if(stancePhaseDelayCounter == 0)

--- a/src/WalkingModule/src/Module.cpp
+++ b/src/WalkingModule/src/Module.cpp
@@ -84,6 +84,9 @@ bool WalkingModule::advanceReferenceSignals()
     m_comHeightVelocity.pop_front();
     m_comHeightVelocity.push_back(m_comHeightVelocity.back());
 
+    m_isStancePhase.pop_front();
+    m_isStancePhase.push_back(m_isStancePhase.back());
+
     // at each sampling time the merge points are decreased by one.
     // If the first merge point is equal to 0 it will be dropped.
     // A new trajectory will be merged at the first merge point or if the deque is empty


### PR DESCRIPTION
This PR should fix the stance phase machinery in the walking module.  In theory, the PR fixes https://github.com/robotology/walking-controllers/issues/66

- https://github.com/robotology/walking-controllers/commit/aa03967036475e705f2afa3e4b1d4a32d843ee6d fixes the bug spot by @S-Dafarra in https://github.com/robotology/walking-controllers/issues/66#issuecomment-683747596
- https://github.com/robotology/walking-controllers/commit/578f87da62c0a0be2efbcef118366a6b781a428d advances the `m_isStancePhase` trajectory as described in https://github.com/robotology/walking-controllers/issues/66#issuecomment-694719465

**Note:** before merging it should be tested on iCub