### PR TITLE
Bugfix in the retargeting client class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ### Added
 
 ### Changed
+- Bugfix while resetting the hand smoother in the `RetargetingClient` (https://github.com/robotology/walking-controllers/pull/75)
 
 ## [0.4.0] - 2020-12-01
 ### Added

--- a/src/RetargetingHelper/src/Helper.cpp
+++ b/src/RetargetingHelper/src/Helper.cpp
@@ -216,8 +216,8 @@ bool RetargetingClient::initialize(const yarp::os::Searchable &config,
 
 bool RetargetingClient::reset(WalkingFK& kinDynWrapper)
 {
-    m_leftHand.data = kinDynWrapper.getLeftHandToWorldTransform();
-    m_rightHand.data = kinDynWrapper.getRightHandToWorldTransform();
+    m_leftHand.data = kinDynWrapper.getHeadToWorldTransform().inverse() * kinDynWrapper.getLeftHandToWorldTransform();
+    m_rightHand.data = kinDynWrapper.getHeadToWorldTransform().inverse() * kinDynWrapper.getRightHandToWorldTransform();
 
     if(m_useHandRetargeting)
     {


### PR DESCRIPTION
This PR fixes a bug in the`RetargetingClient` class. In detail, the hand `transform` in the retargeting client is expressed with respect to the head frame. 