### PR TITLE
Fix missing ctrlLib link in SimplifiedModelControllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+
+## [0.4.1] - 2020-03-02
+
 ### Added
 
 ### Changed
 - Bugfix while resetting the hand smoother in the `RetargetingClient` (https://github.com/robotology/walking-controllers/pull/75)
+- Fixed compilation if iDynTree 3 is used (https://github.com/robotology/walking-controllers/pull/77).
+
 
 ## [0.4.0] - 2020-12-01
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 ## MAIN project
 project(WalkingControllers
-  VERSION 0.4.0)
+  VERSION 0.4.1)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/src/SimplifiedModelControllers/CMakeLists.txt
+++ b/src/SimplifiedModelControllers/CMakeLists.txt
@@ -32,7 +32,8 @@ if(WALKING_CONTROLLERS_COMPILE_SimplifiedModelControllers)
     WalkingControllers::iDynTreeUtilities
     osqp::osqp
     OsqpEigen::OsqpEigen
-    Eigen3::Eigen)
+    Eigen3::Eigen
+    ctrlLib)
 
   add_library(WalkingControllers::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})
 


### PR DESCRIPTION
`SimplifiedModelControllers` is using `iCub::ctrl::Integrator::Integrator`, but is not linking to `ctrlLib` from the `ICUB` CMake project. Before iDynTree 3 this was working thank to some lucky transitive linking, but to avoid problems it is better to link ctrlLib explicitly.