### PR TITLE
Adding more missing link to ctrlLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
-## [0.4.1] - 2020-03-02
+## [0.4.1] - 2020-02-04
 
 ### Added
 
 ### Changed
 - Bugfix while resetting the hand smoother in the `RetargetingClient` (https://github.com/robotology/walking-controllers/pull/75)
-- Fixed compilation if iDynTree 3 is used (https://github.com/robotology/walking-controllers/pull/77).
+- Fixed compilation if iDynTree 3 is used (https://github.com/robotology/walking-controllers/pull/77, https://github.com/robotology/walking-controllers/pull/78).
 
 
 ## [0.4.0] - 2020-12-01

--- a/src/RobotInterface/CMakeLists.txt
+++ b/src/RobotInterface/CMakeLists.txt
@@ -28,6 +28,7 @@ if(WALKING_CONTROLLERS_COMPILE_RobotInterface)
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC
     WalkingControllers::YarpUtilities
     WalkingControllers::iDynTreeUtilities
+    ctrlLib
     PRIVATE Eigen3::Eigen)
 
   add_library(WalkingControllers::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})

--- a/src/WalkingModule/CMakeLists.txt
+++ b/src/WalkingModule/CMakeLists.txt
@@ -53,6 +53,7 @@ if(WALKING_CONTROLLERS_COMPILE_WalkingModule)
     WalkingControllers::WholeBodyControllers
     WalkingControllers::RetargetingHelper
     WalkingControllers::LoggerClient
+    ctrlLib
     )
 
   install(TARGETS ${EXE_TARGET_NAME} DESTINATION bin)


### PR DESCRIPTION
* `WalkingControllersRobotInterface` uses ctrlLib in https://github.com/robotology/walking-controllers/blob/v0.4.0/src/RobotInterface/include/WalkingControllers/RobotInterface/Helper.h#L27 
* `WalkingModule` uses ctrlLib in https://github.com/robotology/walking-controllers/blob/44d2d4c0f8ff63ee689be7559cee6fd01e86ddd1/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h#L51