### PR TITLE
Add Eigen3 link library in WholeBodyControllers component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+- Added Eigen3 dependency in CMakeList.txt for WholeBodyControllers
 
 ## [0.4.1] - 2020-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
-- Added Eigen3 dependency in CMakeList.txt for WholeBodyControllers
+### Added
+
+### Changed
+- Fixed missing link library in `WholeBodyControllers` component  (https://github.com/robotology/walking-controllers/pull/81).
 
 ## [0.4.1] - 2020-02-04
 

--- a/src/WholeBodyControllers/CMakeLists.txt
+++ b/src/WholeBodyControllers/CMakeLists.txt
@@ -42,6 +42,7 @@ if(WALKING_CONTROLLERS_COMPILE_WholeBodyControllers)
     osqp::osqp
     OsqpEigen::OsqpEigen
     ${qpOASES_LIBRARIES}
+    Eigen3::Eigen
     ctrlLib)
 
   add_library(WalkingControllers::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})


### PR DESCRIPTION
Fix Eigen include error:
```
In file included from /home/valentino/work/robotology-superbuild/robotology/walking-controllers/src/WholeBodyControllers/src/InverseKinematics.cpp:21:0:
/home/valentino/work/robotology-superbuild/build/install/include/iDynTree/Core/EigenHelpers.h:16:10: fatal error: Eigen/Dense: No such file or directory
 #include <Eigen/Dense>
          ^~~~~~~~~~~~~
compilation terminated.
```
cc @CarlottaSartore 