### PR TITLE
Bumped UnicyclePlanner required version.

### DIFF
--- a/cmake/WalkingControllersFindDependencies.cmake
+++ b/cmake/WalkingControllersFindDependencies.cmake
@@ -134,7 +134,7 @@ checkandset_dependency(iDynTree)
 find_package(Eigen3 3.2.92 QUIET)
 checkandset_dependency(Eigen3)
 
-find_package(UnicyclePlanner 0.3.102 QUIET)
+find_package(UnicyclePlanner 0.4.0 QUIET)
 checkandset_dependency(UnicyclePlanner)
 
 find_package(osqp QUIET)


### PR DESCRIPTION
This needs https://github.com/robotology/unicycle-footstep-planner/pull/47 to be merged first