### PR TITLE
Add blf dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Eprint = {arXiv:1809.02167},
 * [osqp-eigen](https://github.com/robotology/osqp-eigen): to solve the MPC problem;
 * [qpOASES](https://github.com/robotology-dependencies/qpOASES): to solve the IK problem;
 * [Unicycle footstep planner](https://github.com/robotology/unicycle-footstep-planner/tree/dcmTrajectoryGenerator): to generate a trajectory for the DCM;
+* [bipedal-locomotion-framework](https://github.com/ami-iit/bipedal-locomotion-framework): for locomotion functionalities;
 * [Gazebo](http://gazebosim.org/): for the simulation (tested Gazebo 8, 9 and 10);
 * [Catch2](https://github.com/catchorg/Catch2): to compile the tests.
 


### PR DESCRIPTION
A dependency on blf was added in https://github.com/robotology/walking-controllers/pull/97 but was not documented in the README. 