### PR TITLE
Remove logger from iCubGazeboV3 configuration

### DIFF
--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
@@ -9,7 +9,7 @@ use_QP-IK                          1
 use_osqp                           1
 
 # remove this line if you don't want to save data of the experiment
-dump_data                          1
+dump_data                          0
 
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.5


### PR DESCRIPTION
Currently in the installed `iCubGazeboV3` configuration the option `dump_data` set to true. This means that for running the `WalkingModule`, it is required to have the [`bipedal-locomotion-framework`](https://github.com/ami-iit/bipedal-locomotion-framework) logger module running.

In order to simplify the usage of such application, and make it compatible with the instruction in https://github.com/robotology/walking-controllers#computer-how-to-run-the-simulation, I am changing the default value to false.