### PR TITLE
Enable the minimum jerk trajectory for the DCM first DS phase

### DIFF
--- a/cmake/WalkingControllersFindDependencies.cmake
+++ b/cmake/WalkingControllersFindDependencies.cmake
@@ -134,7 +134,7 @@ checkandset_dependency(iDynTree)
 find_package(Eigen3 3.2.92 QUIET)
 checkandset_dependency(Eigen3)
 
-find_package(UnicyclePlanner 0.4.2 QUIET)
+find_package(UnicyclePlanner 0.4.3 QUIET)
 checkandset_dependency(UnicyclePlanner)
 
 find_package(osqp QUIET)

--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -168,6 +168,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     m_dcmGenerator = m_trajectoryGenerator.addDCMTrajectoryGenerator();
     m_dcmGenerator->setFootOriginOffset(leftZMPDelta, rightZMPDelta);
     m_dcmGenerator->setOmega(sqrt(9.81/comHeight));
+    m_dcmGenerator->setFirstDCMTrajectoryMode(FirstDCMTrajectoryMode::FifthOrderPoly);
     ok = ok && m_dcmGenerator->setLastStepDCMOffsetPercentage(lastStepDCMOffset);
 
     m_correctLeft = true;

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
@@ -20,7 +20,7 @@ minWidth                0.12
 maxAngleVariation       18.0
 minAngleVariation       5.0
 #Timings
-maxStepDuration         1.1
+maxStepDuration         1.31
 minStepDuration         0.7
 
 ##Nominal Values
@@ -32,7 +32,7 @@ stepLandingVelocity     -0.15
 footApexTime            0.5
 comHeightDelta          0.01
 #Timings
-nominalDuration         0.9
+nominalDuration         1.3
 lastStepSwitchTime      0.8
 switchOverSwingRatio    0.3
 


### PR DESCRIPTION
This requires https://github.com/robotology/unicycle-footstep-planner/pull/53