### PR TITLE
Sidesteps

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,37 @@ architecture is required. In details:
 
     ``` sh
     YARP_CLOCK=/clock yarpdev --device JoypadControlServer --use_separate_ports 1 --period 10 --name /joypadDevice/xbox --subdevice SDLJoypad --sticks 0
-
+   
     ```
 2. Run the `WalkingJoypadModule` in the other computer
 
     ```
     YARP_CLOCK=/clock WalkingJoypadModule --device JoypadControlClient --local /joypadInput --remote /joypadDevice/xbox
     ```
+    
+## How to walk sideways
+In order to enable the sideways walking it is necessary to set the parameter ``controlType`` to ``direct`` in the ``plannerParams`` configuration file. In this configuration, the goal set with ``setGoal`` is interpreted as a desired velocity reference for the unicycle. In this case, ``setGoal`` expects three doubles that represent the forward velocity, angular velocity, and lateral velocity. For example
+```
+setGoal (0.0 0.0 1.0)
+```
+will command the robot to step sideways to the left.
+
+In case the planner fails in finding a solution, it is possible to reduce the values in ``saturationFactors`` in the ``plannerParams`` file. These numbers represent conservative factors that multiply the unicycle velocity saturations computed from the other parameters, like the ``minStepDuration``. The first number multiplies the saturation for the linear and lateral velocity. The second number multiplies the angular velocity saturation. Suggested values for ``saturationFactors``:
+- ``personFollowing`` case: ``(0.9, 0.7)``
+- ``direct`` case: ``(0.7, 0.7)``
+
+​    
+## How to control the robot from YARP port
+The ``WalkingModule`` opens a port named by default ``/walking-coordinator/goal:i`` (it can be edited from the main configuration file). This port expects a vector of double of size 2 if the ``controlType`` in ``plannerParams`` is set to ``personFollowing``, or 3 if the value is ``direct``. In the first case, they represent the x and y position in a robot centered frame of the desired point to reach. In the second case, they represent the desired unicycle velocities. 
+
+The range of the numbers is expected to be ``[-1, +1]``. Some scaling can be applied in the main configuration file through the parameter ``goal_port_scaling``. Suggested scaling:
+- ``personFollowing`` case: ``(10.0, 10.0, 1.0)`` (the third input is not considered) 
+- ``direct`` case: ``(0.5, 1.0, 0.5)``
+
+
 
 ## How to dump data
+
 Before running `WalkingModule` check if `dump_data` is set to 1. This parameter is set in a configuration `ini` file depending on the control mode:
 * controlling from the joypad: `src/WalkingModule/app/robots/${YARP_ROBOT_NAME}/dcm_walking_with_joypad.ini`. [Example for the model `iCubGazeboV2_5`](src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_with_joypad.ini#L12)
 * control using the human retargeting: in the same folder `src/WalkingModule/app/robots/${YARP_ROBOT_NAME}`, the configuration files `dcm_walking_hand_retargeting.ini` and `dcm_walking_joint_retargeting.ini`.

--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ In order to run the simulation, the following additional dependency are required
      controller sending `startWalking` command;
    * `stopWalking`: the controller is stopped, in order to start again the
      controller you have to prepare again the robot.
-   * `setGoal x y`: send the desired final position, `x` and `y` are doubles expressed in iCub fixed frame, in meters. Send this command after `startWalking`.
+   * `setGoal x y`: send the desired input to the planner. Send this command after `startWalking`.
 
    Example sequence:
    ```
    prepareRobot
    startWalking
-   setGoal 1.0 0.0
-   setGoal 1.0 0.0
+   setGoal (1.0 0.0)
+   setGoal (1.0 0.0)
    stopWalking
    ```
 

--- a/cmake/WalkingControllersFindDependencies.cmake
+++ b/cmake/WalkingControllersFindDependencies.cmake
@@ -134,7 +134,7 @@ checkandset_dependency(iDynTree)
 find_package(Eigen3 3.2.92 QUIET)
 checkandset_dependency(Eigen3)
 
-find_package(UnicyclePlanner 0.4.3 QUIET)
+find_package(UnicyclePlanner 0.5.0 QUIET)
 checkandset_dependency(UnicyclePlanner)
 
 find_package(osqp QUIET)

--- a/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
@@ -16,10 +16,6 @@ sticks    0
 deadzone        0.05
 fullscale       1.0
 
-# scale factors
-scale_x         10.0
-scale_y         10.0
-
 # Port names
 rpcServerPort_name              /walking-coordinator/rpc
 rpcClientPort_name              /rpc

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -51,19 +51,6 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
         return false;
     }
 
-    // set scaling factors
-    if(!YarpUtilities::getNumberFromSearchable(rf, "scale_x", m_scaleX))
-    {
-        yError() << "[configure] Unable to get a double from a searchable";
-        return false;
-    }
-
-    if(!YarpUtilities::getNumberFromSearchable(rf, "scale_y", m_scaleY))
-    {
-        yError() << "[configure] Unable to get a double from a searchable";
-        return false;
-    }
-
     // set the polydriver
     yarp::os::Property conf;
     std::string deviceName;
@@ -197,14 +184,14 @@ bool JoypadModule::updateModule()
     m_joypadController->getButton(7, r1Button);
 
     // get the values from stick
-    double x, y;
-    m_joypadController->getAxis(0, x);
-    m_joypadController->getAxis(1, y);
+    double x, y, z;
+    m_joypadController->getAxis(0, y);
+    m_joypadController->getAxis(1, x);
+    m_joypadController->getAxis(2, z);
 
-    x = -m_scaleX * deadzone(x);
-    y = -m_scaleY * deadzone(y);
-
-    std::swap(x,y);
+    x = -deadzone(x);
+    y = -deadzone(y);
+    z = -deadzone(z);
 
     if(aButton > 0)
     {
@@ -240,6 +227,7 @@ bool JoypadModule::updateModule()
         goal.clear();
         goal.push_back(x);
         goal.push_back(y);
+        goal.push_back(z);
         m_robotGoalPort.write();
     }
     return true;

--- a/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
+++ b/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
@@ -66,7 +66,8 @@ namespace WalkingControllers
         iDynTree::Transform m_measuredTransformLeft; /**< Measured transformation between the left foot and the world frame. (w_H_lf) */
         iDynTree::Transform m_measuredTransformRight; /**< Measured transformation between the right foot and the world frame. (w_H_rf) */
 
-        iDynTree::Vector2 m_desiredPoint; /**< Desired final position of the x-y projection of the CoM. */
+        iDynTree::Vector2 m_personFollowingDesiredPoint; /**< Desired final position of the x-y projection of the CoM. */
+        iDynTree::Vector3 m_desiredDirectControl; /**< Desired control input to send to the Unicycle Planner. */
 
         iDynTree::Vector2 m_DCMBoundaryConditionAtMergePointPosition; /**< DCM position at the merge point. */
         iDynTree::Vector2 m_DCMBoundaryConditionAtMergePointVelocity; /**< DCM velocity at the merge point. */
@@ -129,12 +130,12 @@ namespace WalkingControllers
          * @param DCMBoundaryConditionAtMergePointVelocity is the velocity of the DCM at the merge point;
          * @param correctLeft todo;
          * @param measured Measured transformation between the stance foot and the world frame. (w_H_{stancefoot});
-         * @param desiredPosition final desired position of the projection of the CoM.
+         * @param desiredInput desiredInput to the unicycle planner
          * @return true/false in case of success/failure.
          */
         bool updateTrajectories(double initTime, const iDynTree::Vector2& DCMBoundaryConditionAtMergePointPosition,
                                 const iDynTree::Vector2& DCMBoundaryConditionAtMergePointVelocity, bool correctLeft,
-                                const iDynTree::Transform& measured, const iDynTree::Vector2& desiredPosition);
+                                const iDynTree::Transform& measured, const iDynTree::VectorDynSize& plannerDesiredInput);
 
         /**
          * @brief Set the free space ellipse in which the robot can walk.

--- a/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
+++ b/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
@@ -38,6 +38,7 @@ namespace WalkingControllers
     class TrajectoryGenerator
     {
         UnicycleGenerator m_trajectoryGenerator; /**< UnicycleTrajectoryGenerator object. */
+        UnicycleController m_unicycleController; /**< The controller used by the unicycle. */
         std::shared_ptr<DCMTrajectoryGenerator> m_dcmGenerator;
         std::shared_ptr<CoMHeightTrajectoryGenerator> m_heightGenerator;
         std::shared_ptr<FeetGenerator> m_feetGenerator;

--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -101,6 +101,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     double positionWeight = config.check("positionWeight", yarp::os::Value(1.0)).asFloat64();
     double slowWhenTurningGain = config.check("slowWhenTurningGain", yarp::os::Value(0.0)).asFloat64();
     double slowWhenBackwardFactor = config.check("slowWhenBackwardFactor", yarp::os::Value(1.0)).asFloat64();
+    double slowWhenSidewaysFactor = config.check("slowWhenSidewaysFactor", yarp::os::Value(1.0)).asFloat64();
     double maxStepLength = config.check("maxStepLength", yarp::os::Value(0.05)).asFloat64();
     double minStepLength = config.check("minStepLength", yarp::os::Value(0.005)).asFloat64();
     double minWidth = config.check("minWidth", yarp::os::Value(0.03)).asFloat64();
@@ -156,6 +157,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     ok = ok && unicyclePlanner->setMinimumStepLength(minStepLength);
     ok = ok && unicyclePlanner->setSlowWhenTurnGain(slowWhenTurningGain);
     ok = ok && unicyclePlanner->setSlowWhenBackwardFactor(slowWhenBackwardFactor);
+    ok = ok && unicyclePlanner->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor);
     unicyclePlanner->setLeftFootYawOffsetInRadians(m_leftYawDeltaInRad);
     unicyclePlanner->setRightFootYawOffsetInRadians(m_rightYawDeltaInRad);
     unicyclePlanner->addTerminalStep(true);

--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -69,14 +69,21 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     iDynTree::Vector2 leftZMPDelta;
     if(!YarpUtilities::getVectorFromSearchable(config, "leftZMPDelta", leftZMPDelta))
     {
-        yError() << "[configurePlanner] Initialization failed while reading rStancePosition vector.";
+        yError() << "[configurePlanner] Initialization failed while reading leftZMPDelta vector.";
         return false;
     }
 
     iDynTree::Vector2 rightZMPDelta;
     if(!YarpUtilities::getVectorFromSearchable(config, "rightZMPDelta", rightZMPDelta))
     {
-        yError() << "[configurePlanner] Initialization failed while reading rStancePosition vector.";
+        yError() << "[configurePlanner] Initialization failed while reading rightZMPDelta vector.";
+        return false;
+    }
+
+    iDynTree::Vector2 saturationFactors;
+    if(!YarpUtilities::getVectorFromSearchable(config, "saturationFactors", saturationFactors))
+    {
+        yError() << "[configurePlanner] Initialization failed while reading saturationFactors vector.";
         return false;
     }
 
@@ -158,6 +165,7 @@ bool TrajectoryGenerator::configurePlanner(const yarp::os::Searchable& config)
     ok = ok && unicyclePlanner->setSlowWhenTurnGain(slowWhenTurningGain);
     ok = ok && unicyclePlanner->setSlowWhenBackwardFactor(slowWhenBackwardFactor);
     ok = ok && unicyclePlanner->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor);
+    ok = ok && unicyclePlanner->setSaturationsConservativeFactors(saturationFactors(0), saturationFactors(1));
     unicyclePlanner->setLeftFootYawOffsetInRadians(m_leftYawDeltaInRad);
     unicyclePlanner->setRightFootYawOffsetInRadians(m_rightYawDeltaInRad);
     unicyclePlanner->addTerminalStep(true);

--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -571,13 +571,19 @@ bool TrajectoryGenerator::updateTrajectories(double initTime, const iDynTree::Ve
 
         if (m_unicycleController == UnicycleController::PERSON_FOLLOWING)
         {
-            if (plannerDesiredInput.size() != 2)
+            if (plannerDesiredInput.size() < 2)
             {
                 yErrorThrottle(1.0) << "[updateTrajectories] The plannerDesiredInput is supposed to have dimension 2, while it has dimension" << plannerDesiredInput.size()
                                     << ". Using zero input.";
             }
             else
             {
+                if (plannerDesiredInput.size() > 2)
+                {
+                    yWarningOnce() << "[updateTrajectories] The plannerDesiredInput is supposed to have dimension 2, while it has dimension" << plannerDesiredInput.size()
+                                        << ". Using only the first two inputs. This warning will be showed only once.";
+                }
+
                 m_personFollowingDesiredPoint(0) = plannerDesiredInput(0);
                 m_personFollowingDesiredPoint(1) = plannerDesiredInput(1);
             }

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          10.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.20

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_hand_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_hand_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_joint_retargeting.ini
@@ -32,6 +32,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_with_joypad.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          10.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.2
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.7, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.21

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
@@ -11,14 +11,14 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
-slowWhenSidewaysFactor  0.5
+slowWhenSidewaysFactor  0.2
 
 ##Bounds
 #Step length
 maxStepLength           0.21
 minStepLength           0.05
 #Width
-minWidth                0.12
+minWidth                0.10
 #Angle Variations in DEGREES
 #maxAngleVariation       12.0
 maxAngleVariation       22.0

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
@@ -2,7 +2,7 @@
 plannerHorizon          10.0
 
 ##Unicycle controller. Available types: personFollowing, direct
-controlType             personFollowing
+controlType             direct
 
 ##Unicycle Related Quantities
 unicycleGain            10.0

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_hand_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_hand_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.4, 0.3)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_joint_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.4, 0.3)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.4, 0.3)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
@@ -34,7 +34,7 @@ skip_dcm_controller                  0
 goal_port_suffix                    /goal:i
 
 # Scales the input coming from the goal port
-goal_port_scaling                   (10.0, 10.0, 1.0)
+goal_port_scaling                   (1.0, 1.0, 1.0)
 
 # general parameters
 [GENERAL]

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.4, 0.3)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          5.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/hand_retargeting/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.20

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.19

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          5.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/iFeel_joint_retargeting/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.19

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          5.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joint_retargeting/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          10.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.21

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/joypad_control/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     5.0
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_hand_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_hand_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_iFeel_joint_retargeting.ini
@@ -14,6 +14,12 @@ use_QP-IK                          1
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_joint_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_with_joypad.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     2.0
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.2
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.7, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.27

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
@@ -2,7 +2,7 @@
 plannerHorizon          20.0
 
 ##Unicycle controller. Available types: personFollowing, direct
-controlType             personFollowing
+controlType             direct
 
 ##Unicycle Related Quantities
 unicycleGain            10.0
@@ -10,8 +10,8 @@ referencePosition       (0.1 0.0)
 timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     2.0
-slowWhenBackwardFactor  0.7
-slowWhenSidewaysFactor  0.5
+slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.2
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          1.0
 slowWhenTurningGain     2.0
 slowWhenBackwardFactor  0.7
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          20.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/iFeel_joint_retargeting/robotControl.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/iFeel_joint_retargeting/robotControl.ini
@@ -28,7 +28,7 @@ joint_is_stiff_mode     (true, true, true,
                          true, true, true, true, false, true)
 
 # if true a good joint traking is considered mandatory
-good_tracking_required  (true, true, false,
+good_tracking_required  (false, false, false
                          true, true, true,
                          false, false, true, true, false, false, false,
                          false, false, true, true, false, false, false,

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_hand_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_hand_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.35, 0.25)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
@@ -34,7 +34,7 @@ skip_dcm_controller                  1
 goal_port_suffix                    /goal:i
 
 # Scales the input coming from the goal port
-goal_port_scaling                   (10.0, 10.0, 1.0)
+goal_port_scaling                   (0.5, 1.0, 0.5)
 
 # general parameters
 [GENERAL]

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.35, 0.25)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_joint_retargeting.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.35, 0.25)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
@@ -34,7 +34,7 @@ skip_dcm_controller                  1
 goal_port_suffix                    /goal:i
 
 # Scales the input coming from the goal port
-goal_port_scaling                   (10.0, 10.0, 1.0)
+goal_port_scaling                   (0.5, 1.0, 0.5)
 
 # general parameters
 [GENERAL]

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.35, 0.25)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
@@ -1,6 +1,9 @@
 ##Timings
 plannerHorizon          6.0
 
+##Unicycle controller. Available types: personFollowing, direct
+controlType             personFollowing
+
 ##Unicycle Related Quantities
 unicycleGain            10.0
 referencePosition       (0.1 0.0)

--- a/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
@@ -11,6 +11,7 @@ timeWeight              2.5
 positionWeight          0.1
 slowWhenTurningGain     1.4
 slowWhenBackwardFactor  1.0
+slowWhenSidewaysFactor  0.5
 
 ##Bounds
 #Step length

--- a/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking/common/plannerParams.ini
@@ -13,6 +13,12 @@ slowWhenTurningGain     1.4
 slowWhenBackwardFactor  1.0
 slowWhenSidewaysFactor  0.5
 
+# Conservative factors that multiply the unicycle velocity saturations
+# computed from the other parameters, like the minStepDuration.
+# The first number multiplies the saturation for the linear and lateral
+# velocity. The second number multiplies the angular velocity saturation.
+saturationFactors       (0.9, 0.7)
+
 ##Bounds
 #Step length
 maxStepLength           0.15

--- a/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/icubGazeboSim/dcm_walking_with_joypad.ini
@@ -30,6 +30,12 @@ maximum_local_zmp                   (0.3, 0.2)
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
+# The goal port receives 2 or 3 doubles according to the selected planner controller
+goal_port_suffix                    /goal:i
+
+# Scales the input coming from the goal port
+goal_port_scaling                   (10.0, 10.0, 1.0)
+
 # general parameters
 [GENERAL]
 name                    walking-coordinator

--- a/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
+++ b/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
@@ -144,7 +144,7 @@ namespace WalkingControllers
 
         std::mutex m_mutex; /**< Mutex. */
 
-        iDynTree::VectorDynSize m_plannerInput;
+        iDynTree::VectorDynSize m_plannerInput, m_goalScaling;
 
         // debug
         std::unique_ptr<iCub::ctrl::Integrator> m_velocityIntegral{nullptr};
@@ -251,6 +251,12 @@ namespace WalkingControllers
          * Reset the entire controller architecture
          */
         void reset();
+
+        /**
+         * @brief Apply the scaling on the input from goal port.
+         * @param plannerInput The raw data read from the goal port.
+         */
+        void applyGoalScaling(yarp::sig::Vector &plannerInput);
 
     public:
 

--- a/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
+++ b/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
@@ -144,7 +144,7 @@ namespace WalkingControllers
 
         std::mutex m_mutex; /**< Mutex. */
 
-        iDynTree::Vector2 m_desiredPosition;
+        iDynTree::VectorDynSize m_plannerInput;
 
         // debug
         std::unique_ptr<iCub::ctrl::Integrator> m_velocityIntegral{nullptr};
@@ -218,12 +218,12 @@ namespace WalkingControllers
          * @param isLeftSwinging todo wrong name?;
          * @param measuredTransform transformation between the world and the (stance/swing??) foot;
          * @param mergePoint is the instant at which the old and the new trajectory will be merged;
-         * @param desiredPosition final desired position of the projection of the CoM.
+         * @param plannerDesiredInput The desired input to the planner.
          * @return true/false in case of success/failure.
          */
         bool askNewTrajectories(const double& initTime, const bool& isLeftSwinging,
                                 const iDynTree::Transform& measuredTransform,
-                                const size_t& mergePoint, const iDynTree::Vector2& desiredPosition);
+                                const size_t& mergePoint, const iDynTree::VectorDynSize &plannerDesiredInput);
 
         /**
          * Update the old trajectory.
@@ -235,14 +235,17 @@ namespace WalkingControllers
         bool updateTrajectories(const size_t& mergePoint);
 
         /**
-         * Set the input of the planner. The desired position is expressed using a
+         * Set the input of the planner. The size of the input is different according to the
+         * controller type of the planner.
+         * If using the personFollowing controller, the input is a desired position is expressed using a
          * reference frame attached to the robot. The X axis points forward while the
          * Y axis points on the left.
-         * @param x desired forward position of the robot
-         * @param y desired lateral position of the robot
+         * If the controller is the direct one, the input sets the desired control inputs for the unicycle,
+         * namely the forward, angular and lateral velocity.
+         * @param plannerInput The input to the planner
          * @return true/false in case of success/failure.
          */
-        bool setPlannerInput(double x, double y);
+        bool setPlannerInput(const yarp::sig::Vector &plannerInput);
 
         /**
          * Reset the entire controller architecture
@@ -289,12 +292,10 @@ namespace WalkingControllers
         virtual bool startWalking() override;
 
         /**
-         * set the desired final position of the CoM.
-         * @param x desired x position of the CoM;
-         * @param y desired y position of the CoM.
-         * @return true in case of success and false otherwise.
+         * Set the desired goal position to the planner.
+         * @return true/false in case of success/failure;
          */
-        virtual bool setGoal(double x, double y) override;
+        virtual bool setGoal(const yarp::sig::Vector& plannerInput) override;
 
         /**
          * Pause walking.

--- a/src/WalkingModule/thrifts/WalkingCommands.thrift
+++ b/src/WalkingModule/thrifts/WalkingCommands.thrift
@@ -6,6 +6,13 @@
  * @date 2018
  */
 
+struct YarpVector {
+  1: list<double> content;
+} (
+  yarp.name = "yarp::sig::Vector"
+  yarp.includefile="yarp/sig/Vector.h"
+)
+
 service WalkingCommands
 {
     /**
@@ -23,11 +30,10 @@ service WalkingCommands
     bool startWalking();
 
     /**
-     * Set the desired goal position. It is important to notice that
-     * x and y are expressed in the iCub main frame.
+     * Set the desired goal position to the planner.
      * @return true/false in case of success/failure;
      */
-    bool setGoal(1:double x, 2:double y);
+    bool setGoal(1:YarpVector plannerInput);
 
     /**
      * Pause the walking controller


### PR DESCRIPTION
This PR needs https://github.com/robotology/unicycle-footstep-planner/pull/54 to be merged first.

This also changes the syntax to call ``setGoal``. Now, instead of sending
```
setGoal 10.0 0.0
```
it is necessary to do
```
setGoal (10.0, 0.0)
```

Moreover, now the scaling of the input coming to the ``goal`` port is done directly by the ``WalkingModule``. Hence, we expect to receive inputs in the range [-1, 1].

