### PR TITLE
Print the timers status every 10 seconds

### DIFF
--- a/src/WalkingModule/src/Module.cpp
+++ b/src/WalkingModule/src/Module.cpp
@@ -413,7 +413,7 @@ bool WalkingModule::configure(yarp::os::ResourceFinder& rf)
 
     // time profiler
     m_profiler = std::make_unique<TimeProfiler>();
-    m_profiler->setPeriod(round(0.1 / m_dT));
+    m_profiler->setPeriod(round(10 / m_dT));
     if(m_useMPC)
         m_profiler->addTimer("MPC");
 


### PR DESCRIPTION
This goes in the direction to reduce the pollution of the terminal while the application runs