### PR TITLE
[Draft] Add conda-forge-based CI job

### DIFF
--- a/.github/workflows/conda-forge-ci.yaml
+++ b/.github/workflows/conda-forge-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Dependencies
       shell: bash -l {0}
       run: |
-        mamba install -c conda-force -c robotology cmake compilers make ninja pkg-config yarp-cxx icub-contrib-common icub-main qpoases osqp-eigen unicycle-footstep-planner catch2
+        mamba install -c conda-forge -c robotology cmake compilers make ninja pkg-config yarp-cxx icub-contrib-common icub-main qpoases osqp-eigen unicycle-footstep-planner catch2
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-forge-ci.yaml
+++ b/.github/workflows/conda-forge-ci.yaml
@@ -1,0 +1,61 @@
+name: C++ CI Workflow with conda-forge dependencies
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
+jobs:
+  build:
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-latest, windows-2019, macOS-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+
+    - name: Dependencies
+      shell: bash -l {0}
+      run: |
+        mamba install -c conda-force -c robotology cmake compilers make ninja pkg-config yarp-cxx icub-contrib-common icub-main qpoases osqp-eigen unicycle-footstep-planner catch2
+
+    - name: Configure [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Configure [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }}


### PR DESCRIPTION
I opened this to debug https://github.com/robotology/robotology-superbuild/issues/1269, but for now it fails as we do not have any blf 0.9 package on conda for now.