### PR TITLE
RetargetingHelper: Remove spurious blf include

### DIFF
--- a/src/RetargetingHelper/include/WalkingControllers/RetargetingHelper/Helper.h
+++ b/src/RetargetingHelper/include/WalkingControllers/RetargetingHelper/Helper.h
@@ -10,7 +10,6 @@
 #define WALKING_CONTROLLERS_RETARGETING_HELPER_HELPER_H
 
 // std
-#include <BipedalLocomotion/ContinuousDynamicalSystem/FirstOrderSmoother.h>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
The header seems not be used, and a leftover from https://github.com/robotology/walking-controllers/pull/118 .

Fix https://github.com/robotology/robotology-superbuild/issues/1269 .