### PR TITLE
Fix not initialized variable in the evaluation of the measured ZMP and some tuning on ergoCubSN000 

### DIFF
--- a/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking/common/plannerParams.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking/common/plannerParams.ini
@@ -32,7 +32,7 @@ maxAngleVariation       18.0
 minAngleVariation       5.0
 #Timings
 maxStepDuration         1.5
-minStepDuration         0.5
+minStepDuration         0.65
 
 ##Nominal Values
 #Width
@@ -44,7 +44,7 @@ footApexTime            0.5
 comHeightDelta          0.01
 #Timings
 nominalDuration         1.3
-lastStepSwitchTime      0.5
+lastStepSwitchTime      0.3
 switchOverSwingRatio    0.2
 
 #ZMP Delta
@@ -59,7 +59,7 @@ rightYawDeltaInDeg     0.0
 # If it is 0.5 the final DCM will be in the middle of the two footsteps;
 # If it is 0 the DCM position coincides with the stance foot ZMP;
 # If it is 1 the DCM position coincides with the next foot ZMP position.
-lastStepDCMOffset      0.25
+lastStepDCMOffset      0.1
 
 #MergePoint
 # The ratios of the double support in which it is present a merge point.

--- a/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_iFeel_joint_retargeting.ini
@@ -39,7 +39,7 @@ goal_port_suffix                    /goal:i
 goal_port_scaling                   (0.5, 1.0, 0.5)
 
 # How much in advance the planner should be called. The time is in seconds
-planner_advance_time_in_s           0.02
+planner_advance_time_in_s           0.03
 
 # How much time (in seconds) before failing due to missing feedback
 max_feedback_delay_in_s             1.0

--- a/src/WalkingModule/src/Module.cpp
+++ b/src/WalkingModule/src/Module.cpp
@@ -927,7 +927,13 @@ bool WalkingModule::updateModule()
 
             if (comVelocityNorm > m_maxInitialCoMVelocity)
             {
-                yError() << "[WalkingModule::updateModule] The initial CoM velocity is too high.";
+                yError() << "[WalkingModule::updateModule] The initial CoM velocity is too high (desired:"
+                         << comVelocityNorm << "limit:" << m_maxInitialCoMVelocity << ")."
+                         << "ZMP measured: " << measuredZMP.toString()
+                         << "Desired ZMP"<< desiredZMP.toString()
+                         << "measured com position" << m_FKSolver->getCoMPosition().toString()
+                         << "desired com position" << m_stableDCMModel->getCoMPosition().toString()
+                         << "desired com velocity" << m_stableDCMModel->getCoMVelocity().toString();
                 return false;
             }
         }
@@ -1640,6 +1646,11 @@ bool WalkingModule::startWalking()
         return false;
     }
 
+    // we evaluate the offset between the CoM and the ZMP. This quantities is used only if
+    // remove_zmp_offset is set to true.
+    m_zmpOffset.zero();
+    m_zmpOffsetLocal.zero();
+
     // Adjusting the offset on the ZMP at the begining with respect to CoM in the lateral direction
     iDynTree::Vector2 measuredZMP;
     iDynTree::Vector3 measuredCoM = m_FKSolver->getCoMPosition();
@@ -1658,10 +1669,6 @@ bool WalkingModule::startWalking()
         }
     }
 
-    // we evaluate the offset between the CoM and the ZMP. This quantities is used only if
-    // remove_zmp_offset is set to true.
-    m_zmpOffset.zero();
-    m_zmpOffsetLocal.zero();
     if (m_removeZMPOffset)
     {
         m_zmpOffset(0) = measuredCoM(0) - measuredZMP(0);


### PR DESCRIPTION
This PR fixed a not initialized variable in the evaluation of the ZMP moreover it reduced the walking velocity of ergoCubSN000 and increase the planner_advance_time for iFeelWalking