### PR TITLE
Use BipedalLocomotion::GlobalCoPEvaluator to compute the global CoP

### DIFF
--- a/cmake/WalkingControllersDependencies.cmake
+++ b/cmake/WalkingControllersDependencies.cmake
@@ -12,5 +12,5 @@ find_package(OsqpEigen 0.4.0 REQUIRED)
 find_package(qpOASES REQUIRED)
 find_package(BipedalLocomotionFramework 0.9.0
   COMPONENTS VectorsCollection IK ParametersHandlerYarpImplementation
-             ContinuousDynamicalSystem ManifConversions
+             ContinuousDynamicalSystem ManifConversions Contacts
              ParametersHandlerYarpImplementation REQUIRED)

--- a/src/WalkingModule/CMakeLists.txt
+++ b/src/WalkingModule/CMakeLists.txt
@@ -10,6 +10,20 @@ add_walking_controllers_application(
   NAME WalkingModule
   SOURCES src/main.cpp src/Module.cpp ${WalkingModule_THRIFT_GEN_FILES}
   HEADERS include/WalkingControllers/WalkingModule/Module.h
-  LINK_LIBRARIES WalkingControllers::YarpUtilities WalkingControllers::iDynTreeUtilities WalkingControllers::StdUtilities WalkingControllers::TimeProfiler WalkingControllers::RobotInterface WalkingControllers::KinDynWrapper WalkingControllers::TrajectoryPlanner WalkingControllers::SimplifiedModelControllers WalkingControllers::WholeBodyControllers WalkingControllers::RetargetingHelper BipedalLocomotion::VectorsCollection BipedalLocomotion::ParametersHandlerYarpImplementation ctrlLib
+  LINK_LIBRARIES WalkingControllers::YarpUtilities
+                 WalkingControllers::iDynTreeUtilities
+                 WalkingControllers::StdUtilities
+                 WalkingControllers::TimeProfiler
+                 WalkingControllers::RobotInterface
+                 WalkingControllers::KinDynWrapper
+                 WalkingControllers::TrajectoryPlanner
+                 WalkingControllers::SimplifiedModelControllers
+                 WalkingControllers::WholeBodyControllers
+                 WalkingControllers::RetargetingHelper
+                 BipedalLocomotion::VectorsCollection
+                 BipedalLocomotion::ParametersHandlerYarpImplementation
+                 BipedalLocomotion::Contacts
+                 BipedalLocomotion::ManifConversions
+                 ctrlLib
   SUBDIRECTORIES app)
 

--- a/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.4, 0.3)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.0001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             -1

--- a/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking_iFeel_joint_retargeting.ini
@@ -16,19 +16,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.000001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                125
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -91,6 +78,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/ergoCubGazeboV1/dcm_walking_with_joypad.ini
@@ -16,19 +16,6 @@ use_BLF-IK                         1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.5
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                -1
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.4, 0.3)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -83,6 +70,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/ergoCubGazeboV1_1/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/ergoCubGazeboV1_1/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.4, 0.3)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.0001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             -1

--- a/src/WalkingModule/app/robots/ergoCubGazeboV1_1/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/ergoCubGazeboV1_1/dcm_walking_with_joypad.ini
@@ -16,19 +16,6 @@ use_BLF-IK                         1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.5
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                -1
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.4, 0.3)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -83,6 +70,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.35, 0.25)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.000001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             125

--- a/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_iFeel_joint_retargeting.ini
@@ -16,19 +16,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.000001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                125
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -91,6 +78,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN000/dcm_walking_with_joypad.ini
@@ -10,19 +10,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.00001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                25
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -77,6 +64,9 @@ height_reference_frame root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/ergoCubSN001/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN001/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.35, 0.25)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.000001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             125

--- a/src/WalkingModule/app/robots/ergoCubSN001/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/ergoCubSN001/dcm_walking_with_joypad.ini
@@ -10,19 +10,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.00001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                25
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -77,6 +64,9 @@ height_reference_frame root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.3, 0.2)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.0001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             25

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_joint_retargeting.ini
@@ -12,19 +12,6 @@ stance_phase_time_out                1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.02
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                25
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.3, 0.2)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
@@ -88,6 +75,9 @@ height_reference_frame  com
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV2_5/dcm_walking_with_joypad.ini
@@ -10,19 +10,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.02
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                25
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.3, 0.2)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
@@ -87,6 +74,9 @@ height_reference_frame  com
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include lower PID parameters
 [include PID "./dcm_walking/common/pidParams.ini"]

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.4, 0.3)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.0001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             -1

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_joint_retargeting.ini
@@ -14,19 +14,6 @@ use_osqp                           1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.05
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                -1
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.4, 0.3)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
@@ -89,6 +76,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGazeboV3/dcm_walking_with_joypad.ini
@@ -16,19 +16,6 @@ dump_data                          0
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.5
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                -1
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.4, 0.3)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
@@ -86,6 +73,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.3, 0.2)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.0001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             25

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_iFeel_joint_retargeting.ini
@@ -71,6 +71,9 @@ height_reference_frame  com
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
 
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
+
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]
 

--- a/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGenova04/dcm_walking_with_joypad.ini
@@ -14,19 +14,6 @@ use_QP-IK                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.02
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.0001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                25
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.3, 0.2)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  0
 
@@ -84,6 +71,9 @@ height_reference_frame  com
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/globalCoPEvaluator.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking/common/globalCoPEvaluator.ini
@@ -1,0 +1,14 @@
+# Minimum force to consider the CoP valid.
+minimum_normal_force                1.0
+
+# Limit to consider the CoP valid.
+#                                    |x|  |y|
+cop_admissible_limits               (0.35, 0.25)
+
+# Tolerance radius to consider the measured CoP constant.
+constant_cop_tolerance              0.000001
+
+# Consecutive times in which the CoP remains constant.
+# If this limit is reached, the module stops.
+# Use a negative value to disable.
+constant_cop_max_counter             125

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_iFeel_joint_retargeting.ini
@@ -16,19 +16,6 @@ dump_data                          1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.000001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                125
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -91,6 +78,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
+++ b/src/WalkingModule/app/robots/iCubGenova09/dcm_walking_with_joypad.ini
@@ -16,19 +16,6 @@ use_BLF-IK                         1
 # Limit on the maximum initial velocity. This avoids the robot to jump at startup
 max_initial_com_vel                 0.15
 
-# Tolerance radius to consider the measured ZMP constant.
-constant_ZMP_tolerance              0.00001
-
-# Consecutive times in which the ZMP remains constant. If this limit is reached, the module stops. Use a negative value to disable.
-constant_ZMP_counter                125
-
-# Minimum force to consider the ZMP valid.
-minimum_normal_force_ZMP            1.0
-
-# Limit to consider the ZMP valid
-#                                    |x|  |y|
-maximum_local_zmp                   (0.35, 0.25)
-
 # If set to true, the desired ZMP is used directly in the COM/ZMP controller
 skip_dcm_controller                  1
 
@@ -87,6 +74,9 @@ height_reference_frame  root_link
 
 # include FT sensors parameters
 [include FT_SENSORS "./dcm_walking/common/forceTorqueSensors.ini"]
+
+# include CoP evaluator parameters
+[include COP_EVALUATOR "./dcm_walking/common/globalCoPEvaluator.ini"]
 
 # include Logger parameters
 [include WALKING_LOGGER "./dcm_walking/common/walkingLogger.ini"]

--- a/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
+++ b/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
@@ -23,6 +23,7 @@
 
 
 #include <BipedalLocomotion/YarpUtilities/VectorsCollection.h>
+#include <BipedalLocomotion/Contacts/GlobalCoPEvaluator.h>
 
 // iDynTree
 #include <iDynTree/Core/VectorFixSize.h>
@@ -78,13 +79,6 @@ namespace WalkingControllers
         iDynTree::Position m_zmpOffset; /** < Offset reading the zmp at the beginning*/
         iDynTree::Position m_zmpOffsetLocal; /** < Offset in the local frame*/
 
-        iDynTree::Vector2 m_previousZMP; /**< Previous ZMP value to check if the ZMP was constant for a while. */
-        int m_constantZMPCounter; /**< Counter to check for how long the ZMP was constant. */
-        double m_constantZMPTolerance; /**< Tolerance to consider the ZMP constant. */
-        int m_constantZMPMaxCounter; /**< Max counter value for triggering the error on the constant measured ZMP. */
-        double m_minimumNormalForceZMP; /**< Minimum force value to consider a contact stable. */
-        iDynTree::Vector2 m_maxZMP; /**< Max value to consider the local ZMP valid. */
-
         std::unique_ptr<RobotInterface> m_robotControlHelper; /**< Robot control helper. */
         std::unique_ptr<TrajectoryGenerator> m_trajectoryGenerator; /**< Pointer to the trajectory generator object. */
         std::unique_ptr<FreeSpaceEllipseManager> m_freeSpaceEllipseManager; /**< Pointer to the free space ellipse manager. */
@@ -98,6 +92,7 @@ namespace WalkingControllers
         std::unique_ptr<WalkingPIDHandler> m_PIDHandler; /**< Pointer to the PID handler object. */
         std::unique_ptr<RetargetingClient> m_retargetingClient; /**< Pointer to the stable DCM dynamics. */
         std::unique_ptr<TimeProfiler> m_profiler; /**< Time profiler. */
+        BipedalLocomotion::Contacts::GlobalCoPEvaluator m_globalCoPEvaluator;
 
         double m_additionalRotationWeightDesired; /**< Desired additional rotational weight matrix. */
         double m_desiredJointsWeight; /**< Desired joint weight matrix. */
@@ -172,7 +167,6 @@ namespace WalkingControllers
          */
         bool advanceReferenceSignals();
 
-
         /**
          * Update the FK solver.
          * @return true in case of success and false otherwise.
@@ -193,11 +187,11 @@ namespace WalkingControllers
                         iDynTree::VectorDynSize &output);
 
         /**
-         * Evaluate the position of Zero momentum point.
-         * @param zmp zero momentum point.
+         * Compute Global CoP.
+         * @param globalCoP is the global CoP.
          * @return true in case of success and false otherwise.
          */
-        bool evaluateZMP(iDynTree::Vector2& zmp);
+        bool computeGlobalCoP(Eigen::Ref<Eigen::Vector2d> globalCoP);
 
         /**
          * Given the two planned feet, it computes the average yaw rotation


### PR DESCRIPTION
With this PR `BipedalLocomotion::GlobalCoPEvaluator` is used to compute the global CoP for the walking controller. Thanks to this we centralize the code used to compute the quantity in all the projects
