### PR TITLE
Modify time profiler

### DIFF
--- a/src/TimeProfiler/include/WalkingControllers/TimeProfiler/TimeProfiler.h
+++ b/src/TimeProfiler/include/WalkingControllers/TimeProfiler/TimeProfiler.h
@@ -22,8 +22,8 @@ namespace WalkingControllers
      */
     class Timer
     {
-        std::chrono::time_point<std::chrono::system_clock> m_initTime; /**< Init time. */
-        std::chrono::time_point<std::chrono::system_clock> m_endTime; /**< End time. */
+        std::chrono::time_point<std::chrono::steady_clock> m_initTime; /**< Init time. */
+        std::chrono::time_point<std::chrono::steady_clock> m_endTime; /**< End time. */
         double m_averageDuration; /**< Average duration. */
 
     public:

--- a/src/TimeProfiler/include/WalkingControllers/TimeProfiler/TimeProfiler.h
+++ b/src/TimeProfiler/include/WalkingControllers/TimeProfiler/TimeProfiler.h
@@ -12,6 +12,7 @@
 // std
 #include <map>
 #include <memory>
+#include <chrono>
 
 namespace WalkingControllers
 {
@@ -21,8 +22,8 @@ namespace WalkingControllers
      */
     class Timer
     {
-        clock_t m_initTime; /**< Init time. */
-        clock_t m_endTime; /**< End time. */
+        std::chrono::time_point<std::chrono::system_clock> m_initTime; /**< Init time. */
+        std::chrono::time_point<std::chrono::system_clock> m_endTime; /**< End time. */
         double m_averageDuration; /**< Average duration. */
 
     public:

--- a/src/TimeProfiler/src/TimeProfiler.cpp
+++ b/src/TimeProfiler/src/TimeProfiler.cpp
@@ -31,7 +31,7 @@ void Timer::setInitTime()
 
 void Timer::setEndTime()
 {
-    m_endTime = std::chrono::system_clock::now();
+    m_endTime = std::chrono::steady_clock::now();
 }
 
 void Timer::evaluateDuration()

--- a/src/TimeProfiler/src/TimeProfiler.cpp
+++ b/src/TimeProfiler/src/TimeProfiler.cpp
@@ -26,18 +26,18 @@ void Timer::resetAverageDuration()
 
 void Timer::setInitTime()
 {
-    m_initTime = clock();
+    m_initTime = std::chrono::system_clock::now();
 }
 
 void Timer::setEndTime()
 {
-    m_endTime = clock();
+    m_endTime = std::chrono::system_clock::now();
 }
 
 void Timer::evaluateDuration()
 {
-    clock_t duration = m_endTime - m_initTime;
-    m_averageDuration += static_cast<double>(duration) / CLOCKS_PER_SEC * 1000.0;
+    auto duration_ms = std::chrono::duration_cast<std::chrono::microseconds>(m_endTime - m_initTime).count() / 1000.0;
+    m_averageDuration += duration_ms;
 }
 
 void TimeProfiler::setPeriod(int maxCounter)

--- a/src/TimeProfiler/src/TimeProfiler.cpp
+++ b/src/TimeProfiler/src/TimeProfiler.cpp
@@ -26,7 +26,7 @@ void Timer::resetAverageDuration()
 
 void Timer::setInitTime()
 {
-    m_initTime = std::chrono::system_clock::now();
+    m_initTime = std::chrono::steady_clock::now();
 }
 
 void Timer::setEndTime()

--- a/src/WalkingModule/src/Module.cpp
+++ b/src/WalkingModule/src/Module.cpp
@@ -365,12 +365,14 @@ bool WalkingModule::configure(yarp::os::ResourceFinder &rf)
 
     // time profiler
     m_profiler = std::make_unique<TimeProfiler>();
-    m_profiler->setPeriod(round(10 / m_dT));
+    m_profiler->setPeriod(round(1 / m_dT));
     if (m_useMPC)
         m_profiler->addTimer("MPC");
 
     m_profiler->addTimer("IK");
     m_profiler->addTimer("Total");
+    m_profiler->addTimer("Loop");
+    m_profiler->addTimer("Feedback");
 
     // initialize some variables
     m_newTrajectoryRequired = false;
@@ -669,12 +671,16 @@ bool WalkingModule::updateModule()
             }
         }
 
+        m_profiler->setInitTime("Feedback");
+
         // get feedbacks and evaluate useful quantities
         if (!m_robotControlHelper->getFeedbacks(m_feedbackAttempts, m_feedbackAttemptDelay))
         {
             yError() << "[WalkingModule::updateModule] Unable to get the feedback.";
             return false;
         }
+
+        m_profiler->setEndTime("Feedback");
 
         // if the retargeting is not in the approaching phase we can set the stance/walking phase
         if (!m_retargetingClient->isApproachingPhase())
@@ -1039,12 +1045,19 @@ bool WalkingModule::updateModule()
 
         m_retargetingClient->setRobotBaseOrientation(yawRotation.inverse());
 
+        if (!m_firstRun)
+        {
+            m_profiler->setEndTime("Loop");
+        }
+
         m_firstRun = false;
 
         m_profiler->setEndTime("Total");
 
         // print timings
         m_profiler->profiling();
+
+        m_profiler->setInitTime("Loop");
     }
     return true;
 }


### PR DESCRIPTION
@S-Dafarra modified the [TimeProfiler](https://github.com/robotology/walking-controllers/blob/56071b8ca640800667bb81b185c58307c7303ca7/src/TimeProfiler/src/TimeProfiler.cpp) to use the `std::chrono` to get the time. Moreover, he added a check on the time required to get the feedback in the [WalkingModule](https://github.com/robotology/walking-controllers/blob/56071b8ca640800667bb81b185c58307c7303ca7/src/WalkingModule/src/Module.cpp).