### PR TITLE
License the repo under the BSD-3-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,28 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+BSD 3-Clause License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) Fondazione Istituto Italiano di Tecnologia (IIT)
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  0. Additional Definitions.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MATLAB/Logger/initLogger.m
+++ b/MATLAB/Logger/initLogger.m
@@ -2,17 +2,8 @@
 % /**
 %  * Copyright (C): copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
 %  * @author: Giulio Romualdi
-%  * Permission is granted to copy, distribute, and/or modify this program
-%  * under the terms of the GNU General Public License, version 2 or any
-%  * later version published by the Free Software Foundation.
-%  *
-%  * A copy of the license can be found at
-%  * http://www.robotcub.org/icub/license/gpl.txt
-%  *
-%  * This program is distributed in the hope that it will be useful, but
-%  * WITHOUT ANY WARRANTY; without even the implied warranty of
-%  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-%  * Public License for more details
+%  * SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+%  * SPDX-License-Identifier: BSD-3-Clause
 %  */
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/JoypadModule/include/WalkingControllers/JoypadModule/Module.h
+++ b/src/JoypadModule/include/WalkingControllers/JoypadModule/Module.h
@@ -1,10 +1,5 @@
-/**
- * @file JoypadModule.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_JOYPAD_MODULE_HPP
 #define WALKING_JOYPAD_MODULE_HPP

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -1,10 +1,5 @@
-/**
- * @file JoypadModule.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/JoypadModule/src/main.cpp
+++ b/src/JoypadModule/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/KinDynWrapper/include/WalkingControllers/KinDynWrapper/Wrapper.h
+++ b/src/KinDynWrapper/include/WalkingControllers/KinDynWrapper/Wrapper.h
@@ -1,10 +1,5 @@
-/**
- * @file Wrapper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_KINDYN_WRAPPER_WRAPPER_H
 #define WALKING_CONTROLLERS_KINDYN_WRAPPER_WRAPPER_H

--- a/src/KinDynWrapper/src/Wrapper.cpp
+++ b/src/KinDynWrapper/src/Wrapper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Wrapper.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <cmath>

--- a/src/RetargetingHelper/include/WalkingControllers/RetargetingHelper/Helper.h
+++ b/src/RetargetingHelper/include/WalkingControllers/RetargetingHelper/Helper.h
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2019
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_RETARGETING_HELPER_HELPER_H
 #define WALKING_CONTROLLERS_RETARGETING_HELPER_HELPER_H

--- a/src/RetargetingHelper/src/Helper.cpp
+++ b/src/RetargetingHelper/src/Helper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2019
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <yarp/os/LogStream.h>
 #include <yarp/sig/Vector.h>

--- a/src/RobotInterface/include/WalkingControllers/RobotInterface/Helper.h
+++ b/src/RobotInterface/include/WalkingControllers/RobotInterface/Helper.h
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2019
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_ROBOT_HELPER_HELPER_H
 #define WALKING_CONTROLLERS_ROBOT_HELPER_HELPER_H

--- a/src/RobotInterface/src/Helper.cpp
+++ b/src/RobotInterface/src/Helper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2024 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2024
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <iDynTree/Utils.h>
 #include <iDynTree/EigenHelpers.h>

--- a/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/DCMModelPredictiveController.h
+++ b/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/DCMModelPredictiveController.h
@@ -1,10 +1,5 @@
-/**
- * @file DCMModelPredictiveController.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #ifndef WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_DCM_MPC_H

--- a/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/DCMReactiveController.h
+++ b/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/DCMReactiveController.h
@@ -1,10 +1,5 @@
-/**
- * @file DCMReactiveController.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_DCM_REACTIVE_CONTROLLER_H
 #define WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_DCM_REACTIVE_CONTROLLER_H

--- a/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/MPCSolver.h
+++ b/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/MPCSolver.h
@@ -1,10 +1,5 @@
-/**
- * @file MPCSolver.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_MPC_SOLVER_H
 #define WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_MPC_SOLVER_H

--- a/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/ZMPController.h
+++ b/src/SimplifiedModelControllers/include/WalkingControllers/SimplifiedModelControllers/ZMPController.h
@@ -1,10 +1,5 @@
-/**
- * @file ZMPController.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_ZMP_CONTROLLER_H
 #define WALKING_CONTROLLERS_SIMPLIFIED_MODEL_CONTROLLERS_ZMP_CONTROLLER_H

--- a/src/SimplifiedModelControllers/src/DCMModelPredictiveController.cpp
+++ b/src/SimplifiedModelControllers/src/DCMModelPredictiveController.cpp
@@ -1,10 +1,5 @@
-/**
- * @file WalkingDCMModelPredictiveController.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #ifndef NOMINMAX

--- a/src/SimplifiedModelControllers/src/DCMReactiveController.cpp
+++ b/src/SimplifiedModelControllers/src/DCMReactiveController.cpp
@@ -1,10 +1,5 @@
-/**
- * @file WalkingDCMReactiveController.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/SimplifiedModelControllers/src/MPCSolver.cpp
+++ b/src/SimplifiedModelControllers/src/MPCSolver.cpp
@@ -1,10 +1,5 @@
-/**
- * @file MPCSolver.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // iDynTree
 #include <iDynTree/EigenHelpers.h>

--- a/src/SimplifiedModelControllers/src/ZMPController.cpp
+++ b/src/SimplifiedModelControllers/src/ZMPController.cpp
@@ -1,10 +1,5 @@
-/**
- * @file WalkingZMPController.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/StdUtilities/include/WalkingControllers/StdUtilities/Helper.h
+++ b/src/StdUtilities/include/WalkingControllers/StdUtilities/Helper.h
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_STD_HELPER_H
 #define WALKING_CONTROLLERS_STD_HELPER_H

--- a/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/FreeSpaceEllipseManager.h
+++ b/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/FreeSpaceEllipseManager.h
@@ -1,10 +1,5 @@
-/**
- * @file FreeSpaceEllipseManager.h
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_TRAJECTORY_PLANNER_FREESPACEELLIPSEMANAGER_H
 #define WALKING_CONTROLLERS_TRAJECTORY_PLANNER_FREESPACEELLIPSEMANAGER_H

--- a/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/StableDCMModel.h
+++ b/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/StableDCMModel.h
@@ -1,10 +1,5 @@
-/**
- * @file StableDCMModel.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_TRAJECTORY_PLANNER_STABLE_DCM_MODEL_H
 #define WALKING_CONTROLLERS_TRAJECTORY_PLANNER_STABLE_DCM_MODEL_H

--- a/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
+++ b/src/TrajectoryPlanner/include/WalkingControllers/TrajectoryPlanner/TrajectoryGenerator.h
@@ -1,10 +1,5 @@
-/**
- * @file TrajectoryGenerator.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #ifndef WALKING_CONTROLLERS_TRAJECTORY_PLANNER_TRAJECTORY_GENERATOR_H

--- a/src/TrajectoryPlanner/src/FreeSpaceEllipseManager.cpp
+++ b/src/TrajectoryPlanner/src/FreeSpaceEllipseManager.cpp
@@ -1,10 +1,5 @@
-/**
- * @file FreeSpaceEllipseManager.cpp
- * @authors Stefano Dafarra <stefano.dafarra@iit.it>
- * @copyright 2021 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2021
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <WalkingControllers/TrajectoryPlanner/FreeSpaceEllipseManager.h>
 #include <WalkingControllers/YarpUtilities/Helper.h>

--- a/src/TrajectoryPlanner/src/StableDCMModel.cpp
+++ b/src/TrajectoryPlanner/src/StableDCMModel.cpp
@@ -1,10 +1,5 @@
-/**
- * @file StableDCMModel.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <math.h>
 

--- a/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
+++ b/src/TrajectoryPlanner/src/TrajectoryGenerator.cpp
@@ -1,10 +1,5 @@
-/**
- * @file TrajectoryGenerator.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
+++ b/src/WalkingModule/include/WalkingControllers/WalkingModule/Module.h
@@ -1,10 +1,5 @@
-/**
- * @file WalkingModule.hpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_MODULE_HPP
 #define WALKING_MODULE_HPP

--- a/src/WalkingModule/src/Module.cpp
+++ b/src/WalkingModule/src/Module.cpp
@@ -1,11 +1,5 @@
-
-/**
- * @file WalkingModule.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <iostream>

--- a/src/WalkingModule/src/main.cpp
+++ b/src/WalkingModule/src/main.cpp
@@ -1,10 +1,5 @@
-/**
- * @file main.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/WalkingModule/thrifts/WalkingCommands.thrift
+++ b/src/WalkingModule/thrifts/WalkingCommands.thrift
@@ -1,10 +1,5 @@
-/**
- * @file walkingCommands.thrift
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 struct YarpVector {
   1: list<double> content;

--- a/src/WholeBodyControllers/include/WalkingControllers/WholeBodyControllers/BLFIK.h
+++ b/src/WholeBodyControllers/include/WalkingControllers/WholeBodyControllers/BLFIK.h
@@ -1,9 +1,5 @@
-/**
- * @file BLFIK.h
- * @authors Giulio Romualdi
- * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the LGPLv2.1 or later, see LGPL.TXT
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_WHOLE_BODY_CONTROLLERS_BLF_IK
 #define WALKING_CONTROLLERS_WHOLE_BODY_CONTROLLERS_BLF_IK

--- a/src/WholeBodyControllers/include/WalkingControllers/WholeBodyControllers/InverseKinematics.h
+++ b/src/WholeBodyControllers/include/WalkingControllers/WholeBodyControllers/InverseKinematics.h
@@ -1,11 +1,5 @@
-/**
- * @file InverseKinematics.h
- * @authors Stefano Dafarra
- *          Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_WHOLE_BODY_CONTROLLERS_CONTROLLERS_IK_H
 #define WALKING_CONTROLLERS_WHOLE_BODY_CONTROLLERS_CONTROLLERS_IK_H

--- a/src/WholeBodyControllers/src/BLFIK.cpp
+++ b/src/WholeBodyControllers/src/BLFIK.cpp
@@ -1,9 +1,5 @@
-/**
- * @file BLFIK.h
- * @authors Giulio Romualdi
- * @copyright 2022 Istituto Italiano di Tecnologia (IIT). This software may be modified and
- * distributed under the terms of the LGPLv2.1 or later, see LGPL.TXT
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <BipedalLocomotion/Conversions/ManifConversions.h>
 #include <BipedalLocomotion/IK/JointTrackingTask.h>

--- a/src/WholeBodyControllers/src/InverseKinematics.cpp
+++ b/src/WholeBodyControllers/src/InverseKinematics.cpp
@@ -1,11 +1,5 @@
-/**
- * @file WalkingInverseKinematics.cpp
- * @authors Stefano Dafarra
- *          Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/all.h>

--- a/src/YarpUtilities/include/WalkingControllers/YarpUtilities/Helper.h
+++ b/src/YarpUtilities/include/WalkingControllers/YarpUtilities/Helper.h
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_YARP_HELPER_H
 #define WALKING_CONTROLLERS_YARP_HELPER_H

--- a/src/YarpUtilities/include/WalkingControllers/YarpUtilities/Helper.tpp
+++ b/src/YarpUtilities/include/WalkingControllers/YarpUtilities/Helper.tpp
@@ -1,10 +1,5 @@
-/**
- * @file Helper.tpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2018 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #include <iostream>

--- a/src/YarpUtilities/src/Helper.cpp
+++ b/src/YarpUtilities/src/Helper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Helper.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2018
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // YARP
 #include <yarp/os/LogStream.h>

--- a/src/iDynTreeUtilities/include/WalkingControllers/iDynTreeUtilities/Helper.h
+++ b/src/iDynTreeUtilities/include/WalkingControllers/iDynTreeUtilities/Helper.h
@@ -1,10 +1,5 @@
-/**
- * @file Helper.h
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2019
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef WALKING_CONTROLLERS_IDYNTREE_HELPER_H
 #define WALKING_CONTROLLERS_IDYNTREE_HELPER_H

--- a/src/iDynTreeUtilities/src/Helper.cpp
+++ b/src/iDynTreeUtilities/src/Helper.cpp
@@ -1,10 +1,5 @@
-/**
- * @file Helper.cpp
- * @authors Giulio Romualdi <giulio.romualdi@iit.it>
- * @copyright 2019 iCub Facility - Istituto Italiano di Tecnologia
- *            Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- * @date 2019
- */
+// SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+// SPDX-License-Identifier: BSD-3-Clause
 
 // std
 #ifndef _USE_MATH_DEFINES


### PR DESCRIPTION
Similar to:
* https://github.com/robotology/idyntree/pull/1089
* https://github.com/robotology/wearables/pull/192
* https://github.com/robotology/human-dynamics-estimation/pull/350 
* https://github.com/robotology/walking-teleoperation/pull/132
* https://github.com/ami-iit/lie-group-controllers/pull/14

(for some reason we skipped that repo when we relicensed all AMIs-mantainer repos).


I also took the occasion to change license headers to SPDX-style tags (see https://spdx.github.io/spdx-spec/v2.3/file-tags/), that are more manageable and machine readable. 

As a result of the cleanup I deleted the authors name, date and file name from the headers as it seems to me more maintainable to just store this information (automatically) in git, if there is any problem in this we can re-introduce them with a follow-up PR, using the `SPDX-FileContributor:` and similar tags.