### PR TITLE
Add `type` config option and possibility to use pedals

### DIFF
--- a/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
@@ -7,16 +7,6 @@ type            gamepad
 deadzone          0.05
 fullscale         1.0
 
-forwardAxis       0
-rotationAxis      1
-sideAxis          2
-prepareButton     0  # A Button
-startButton       1  # B Button
-stopButton        3  # X Button
-pauseButton       4  # Y Button
-connectGoalButton 6  # L1
-connectRpcButton  7  # R1
-disconnectButton  11 # Menu button
 
 connectPortsSeparately          true
 

--- a/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
@@ -7,8 +7,8 @@ type            gamepad
 deadzone          0.05
 fullscale         1.0
 
-forwardAxis       0
-rotationAxis      1
+forwardAxis       1
+rotationAxis      0
 sideAxis          2
 prepareButton     0  # A Button
 startButton       1  # B Button

--- a/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/joypad.ini
@@ -7,6 +7,16 @@ type            gamepad
 deadzone          0.05
 fullscale         1.0
 
+forwardAxis       0
+rotationAxis      1
+sideAxis          2
+prepareButton     0  # A Button
+startButton       1  # B Button
+stopButton        3  # X Button
+pauseButton       4  # Y Button
+connectGoalButton 6  # L1
+connectRpcButton  7  # R1
+disconnectButton  11 # Menu button
 
 connectPortsSeparately          true
 

--- a/src/JoypadModule/app/dcmWalkingJoypad/keyboard.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/keyboard.ini
@@ -1,6 +1,8 @@
 name            joypad
 period          0.05
 
+type            keyboard
+
 # Joypad options
 deadzone        0.0
 fullscale       1.0

--- a/src/JoypadModule/app/dcmWalkingJoypad/keyboard.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/keyboard.ini
@@ -6,8 +6,8 @@ type            keyboard
 # Joypad options
 deadzone        0.0
 fullscale       1.0
-forwardAxis       0
-rotationAxis      1
+forwardAxis       1
+rotationAxis      0
 sideAxis          2
 prepareButton     0 # A Button
 startButton       1 # B Button

--- a/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
@@ -11,9 +11,9 @@ fullscale         1.0
 connectPortsSeparately          true
 
 # copied from gamepad.ini for now
-forwardAxis       0
-rotationAxis      1
-sideAxis          2
+forwardAxis       1
+rotationAxis      2
+sideAxis          0
 
 
 # Port names

--- a/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
@@ -10,18 +10,6 @@ fullscale         1.0
 
 connectPortsSeparately          true
 
-# copied from gamepad.ini for now
-forwardAxis       0
-rotationAxis      1
-sideAxis          2
-prepareButton     0  # A Button
-startButton       1  # B Button
-stopButton        3  # X Button
-pauseButton       4  # Y Button
-connectGoalButton 6  # L1
-connectRpcButton  7  # R1
-disconnectButton  11 # Menu button
-
 # Port names
 rpcServerPort_name              /walking-coordinator/rpc
 rpcClientPort_name              /rpc

--- a/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
@@ -10,6 +10,12 @@ fullscale         1.0
 
 connectPortsSeparately          true
 
+# copied from gamepad.ini for now
+forwardAxis       0
+rotationAxis      1
+sideAxis          2
+
+
 # Port names
 rpcServerPort_name              /walking-coordinator/rpc
 rpcClientPort_name              /rpc

--- a/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
@@ -1,12 +1,16 @@
 name            joypad
 period          0.05
 
-type            gamepad
+type            pedals
+
 
 # Joypad options
 deadzone          0.05
 fullscale         1.0
 
+connectPortsSeparately          true
+
+# copied from gamepad.ini for now
 forwardAxis       0
 rotationAxis      1
 sideAxis          2
@@ -17,8 +21,6 @@ pauseButton       4  # Y Button
 connectGoalButton 6  # L1
 connectRpcButton  7  # R1
 disconnectButton  11 # Menu button
-
-connectPortsSeparately          true
 
 # Port names
 rpcServerPort_name              /walking-coordinator/rpc

--- a/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
+++ b/src/JoypadModule/app/dcmWalkingJoypad/pedals.ini
@@ -5,7 +5,7 @@ type            pedals
 
 
 # Joypad options
-deadzone          0.05
+deadzone          0.2
 fullscale         1.0
 
 connectPortsSeparately          true

--- a/src/JoypadModule/include/WalkingControllers/JoypadModule/Module.h
+++ b/src/JoypadModule/include/WalkingControllers/JoypadModule/Module.h
@@ -51,12 +51,16 @@ namespace WalkingControllers
         std::string m_robotGoalOutputPortName; /**< Name of the robotGoal port (opened by the joypad module) */
         std::string m_robotGoalInputPortName; /**< Name of the robotGoal port (opened by the walking module) */
 
+        std::string m_joypadType; /**< Type of the joypad. pedals, gamepad, etc. */
+
         /**
          * Standard deadzone function.
          * @param input input of the deadzone
          * @return 0 if the abs(input) < abs(deadzone) otherwise return the input scaled.
          */
         double deadzone(const double &input);
+
+        void sendGoal(const double linearVelocity, const double lateralVelocity, const double angularVelocity);
 
     public:
 

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -59,17 +59,26 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
     // connectPortsSeparately is present or set to true
     m_connectPortsSeparately = rf.check(connectPortsTag) && (rf.find(connectPortsTag).isNull() || rf.find(connectPortsTag).asBool());
 
-    std::vector<std::pair<std::string, int &>> joypadInputs = {{"forwardAxis", m_forwardAxis},
-                                                               {"rotationAxis", m_rotationAxis},
-                                                               {"sideAxis", m_sideAxis},
-                                                               {"prepareButton", m_prepareButton},
+    std::vector<std::pair<std::string, int &>> joypadAxes = {{"forwardAxis", m_forwardAxis},
+                                                             {"rotationAxis", m_rotationAxis},
+                                                             {"sideAxis", m_sideAxis}};
+    for (auto &input : joypadAxes)
+    {
+        if (!YarpUtilities::getNumberFromSearchable(rf, input.first, input.second))
+        {
+            yError() << "[configure] Unable to get " << input.first << " from searchable";
+            return false;
+        }
+    }
+
+    std::vector<std::pair<std::string, int &>> joypadButtons = {{"prepareButton", m_prepareButton},
                                                                {"startButton", m_startButton},
                                                                {"pauseButton", m_pauseButton},
                                                                {"stopButton", m_stopButton},
                                                                {"connectGoalButton", m_connectGoalButton},
                                                                {"connectRpcButton", m_connectRpcButton},
                                                                {"disconnectButton", m_disconnectButton}};
-    for (auto &input : joypadInputs)
+    for (auto &input : joypadButtons)
     {
         if (!YarpUtilities::getNumberFromSearchable(rf, input.first, input.second) && m_joypadType != "pedals")
         {
@@ -156,18 +165,18 @@ bool JoypadModule::close()
 }
 
 bool JoypadModule::updateModule()
-{
-    yarp::os::Bottle cmd, outcome;
-    float prepare{0.0}, start{0.0},
+    m_joypadController->getAxis(m_forwardAxis, y);
+    m_joypadController->getAxis(rotationAxis, x);
+    m_joypadController->getAxis(sideAxis, z);
         stop{0.0}, pause{0.0},
         connectGoal{0.0}, connectRpc{0.0}, disconnect{0.0};
 
     // get the values from stick
     double linearVelocity{0.0}, lateralVelocity{0.0}, angularVeloctiy{0.0};
     double x{0.0}, y{0.0}, z{0.0};
-    m_joypadController->getAxis(0, y);
-    m_joypadController->getAxis(1, x);
-    m_joypadController->getAxis(2, z);
+    m_joypadController->getAxis(m_forwardAxis, y);
+    m_joypadController->getAxis(rotationAxis, x);
+    m_joypadController->getAxis(sideAxis, z);
 
     if (m_joypadType == "pedals")
     {

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -166,15 +166,17 @@ bool JoypadModule::close()
 
 bool JoypadModule::updateModule()
 {
-        stop{0.0}, pause{0.0},
-        connectGoal{0.0}, connectRpc{0.0}, disconnect{0.0};
+    yarp::os::Bottle cmd, outcome;
+    float prepare{ 0.0 }, start{ 0.0 },
+          stop{ 0.0 }, pause{ 0.0 },
+          connectGoal{ 0.0 }, connectRpc{ 0.0 }, disconnect { 0.0 };
 
     // get the values from stick
     double linearVelocity{0.0}, lateralVelocity{0.0}, angularVeloctiy{0.0};
     double x{0.0}, y{0.0}, z{0.0};
     m_joypadController->getAxis(m_forwardAxis, y);
-    m_joypadController->getAxis(rotationAxis, x);
-    m_joypadController->getAxis(sideAxis, z);
+    m_joypadController->getAxis(m_rotationAxis, x);
+    m_joypadController->getAxis(m_sideAxis, z);
 
     if (m_joypadType == "pedals")
     {

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -220,7 +220,7 @@ bool JoypadModule::updateModule()
         sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
     }
     // buttons and others only if not type is not pedals
-    else if (m_joypadType != "pedals")
+    else
     {
 
         m_joypadController->getButton(m_prepareButton, prepare);

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -207,10 +207,6 @@ bool JoypadModule::updateModule()
     else if (m_joypadType != "pedals")
     {
 
-        linearVelocity = -deadzone(x);
-        lateralVelocity = -deadzone(y);
-        angularVeloctiy = -deadzone(z);
-
         m_joypadController->getButton(m_prepareButton, prepare);
         m_joypadController->getButton(m_startButton, start);
         m_joypadController->getButton(m_stopButton, stop);

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -16,7 +16,7 @@ using namespace WalkingControllers;
 bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
 {
     // check if the configuration file is empty
-    if(rf.isNull())
+    if (rf.isNull())
     {
         yError() << "[configure] Empty configuration for the force torque sensors.";
         return false;
@@ -27,42 +27,49 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
 
     // set the module name
     std::string name;
-    if(!YarpUtilities::getStringFromSearchable(rf, "name", name))
+    if (!YarpUtilities::getStringFromSearchable(rf, "name", name))
     {
         yError() << "[configure] Unable to get a string from searchable";
         return false;
     }
     setName(name.c_str());
 
+    // get the joypad type
+    if (!YarpUtilities::getStringFromSearchable(rf, "type", m_joypadType))
+    {
+        yError() << "[configure] Unable to get a string from searchable";
+        return false;
+    }
+
     // set the deadzone interval
-    if(!YarpUtilities::getNumberFromSearchable(rf, "deadzone", m_deadzone))
+    if (!YarpUtilities::getNumberFromSearchable(rf, "deadzone", m_deadzone))
     {
         yError() << "[configure] Unable to get a double from a searchable";
         return false;
     }
 
     // set the maximum value measured by the joypad
-    if(!YarpUtilities::getNumberFromSearchable(rf, "fullscale", m_fullscale))
+    if (!YarpUtilities::getNumberFromSearchable(rf, "fullscale", m_fullscale))
     {
         yError() << "[configure] Unable to get a double from a searchable";
         return false;
     }
 
     const std::string connectPortsTag = "connectPortsSeparately";
-    //connectPortsSeparately is present or set to true
+    // connectPortsSeparately is present or set to true
     m_connectPortsSeparately = rf.check(connectPortsTag) && (rf.find(connectPortsTag).isNull() || rf.find(connectPortsTag).asBool());
 
-    std::vector<std::pair<std::string, int&>> joypadInputs = {{"forwardAxis", m_forwardAxis},
-                                                              {"rotationAxis", m_rotationAxis},
-                                                              {"sideAxis", m_sideAxis},
-                                                              {"prepareButton", m_prepareButton},
-                                                              {"startButton", m_startButton},
-                                                              {"pauseButton", m_pauseButton},
-                                                              {"stopButton", m_stopButton},
-                                                              {"connectGoalButton", m_connectGoalButton},
-                                                              {"connectRpcButton", m_connectRpcButton},
-                                                              {"disconnectButton", m_disconnectButton}};
-    for (auto& input : joypadInputs)
+    std::vector<std::pair<std::string, int &>> joypadInputs = {{"forwardAxis", m_forwardAxis},
+                                                               {"rotationAxis", m_rotationAxis},
+                                                               {"sideAxis", m_sideAxis},
+                                                               {"prepareButton", m_prepareButton},
+                                                               {"startButton", m_startButton},
+                                                               {"pauseButton", m_pauseButton},
+                                                               {"stopButton", m_stopButton},
+                                                               {"connectGoalButton", m_connectGoalButton},
+                                                               {"connectRpcButton", m_connectRpcButton},
+                                                               {"disconnectButton", m_disconnectButton}};
+    for (auto &input : joypadInputs)
     {
         if (!YarpUtilities::getNumberFromSearchable(rf, input.first, input.second))
         {
@@ -71,7 +78,7 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
         }
     }
 
-    yarp::os::Bottle& conf = rf.findGroup("JOYPAD_DEVICE");
+    yarp::os::Bottle &conf = rf.findGroup("JOYPAD_DEVICE");
 
     if (conf.isNull())
     {
@@ -80,7 +87,7 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
     }
 
     // Open joypad polydriver
-    if(!m_joypad.open(conf))
+    if (!m_joypad.open(conf))
     {
         yError() << "[configure] Unable to open the polydriver.";
         return false;
@@ -95,7 +102,7 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
     }
 
     std::string portName;
-    if(!YarpUtilities::getStringFromSearchable(rf, "rpcClientPort_name", portName))
+    if (!YarpUtilities::getStringFromSearchable(rf, "rpcClientPort_name", portName))
     {
         yError() << "[configure] Unable to get a string from searchable";
         return false;
@@ -103,14 +110,14 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
     m_rpcClientPortName = "/" + name + portName;
     m_rpcClientPort.open(m_rpcClientPortName);
 
-    if(!YarpUtilities::getStringFromSearchable(rf, "rpcServerPort_name", m_rpcServerPortName))
+    if (!YarpUtilities::getStringFromSearchable(rf, "rpcServerPort_name", m_rpcServerPortName))
     {
         yError() << "[configure] Unable to get a string from searchable";
         return false;
     }
     yarp::os::Network::connect(m_rpcClientPortName, m_rpcServerPortName);
 
-    if(!YarpUtilities::getStringFromSearchable(rf, "robotGoalOutputPort_name", portName))
+    if (!YarpUtilities::getStringFromSearchable(rf, "robotGoalOutputPort_name", portName))
     {
         yError() << "[configure] Unable to get a string from searchable";
         return false;
@@ -118,7 +125,7 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
     m_robotGoalOutputPortName = "/" + name + portName;
     m_robotGoalPort.open(m_robotGoalOutputPortName);
 
-    if(!YarpUtilities::getStringFromSearchable(rf, "robotGoalInputPort_name", m_robotGoalInputPortName))
+    if (!YarpUtilities::getStringFromSearchable(rf, "robotGoalInputPort_name", m_robotGoalInputPortName))
     {
         yError() << "[configure] Unable to get a string from searchable";
         return false;
@@ -151,91 +158,130 @@ bool JoypadModule::close()
 bool JoypadModule::updateModule()
 {
     yarp::os::Bottle cmd, outcome;
-    float prepare{ 0.0 }, start{ 0.0 },
-          stop{ 0.0 }, pause{ 0.0 },
-          connectGoal{ 0.0 }, connectRpc{ 0.0 }, disconnect { 0.0 };
-
-    m_joypadController->getButton(m_prepareButton, prepare);
-    m_joypadController->getButton(m_startButton, start);
-    m_joypadController->getButton(m_stopButton, stop);
-    m_joypadController->getButton(m_pauseButton, pause);
-    m_joypadController->getButton(m_connectGoalButton, connectGoal);
-    m_joypadController->getButton(m_connectRpcButton, connectRpc);
-    m_joypadController->getButton(m_disconnectButton, disconnect);
+    float prepare{0.0}, start{0.0},
+        stop{0.0}, pause{0.0},
+        connectGoal{0.0}, connectRpc{0.0}, disconnect{0.0};
 
     // get the values from stick
-    double x{ 0.0 }, y{ 0.0 }, z{ 0.0 };
+    double linearVelocity{0.0}, lateralVelocity{0.0}, angularVeloctiy{0.0};
+    double x{0.0}, y{0.0}, z{0.0};
     m_joypadController->getAxis(0, y);
     m_joypadController->getAxis(1, x);
     m_joypadController->getAxis(2, z);
 
-    x = -deadzone(x);
-    y = -deadzone(y);
-    z = -deadzone(z);
+    angularVeloctiy = deadzone(z);
 
-    if(prepare > 0)
+    if (m_joypadType == "pedals")
     {
-        yInfo() << "[updateModule] Prepare robot";
-        cmd.addString("prepareRobot");
-        m_rpcClientPort.write(cmd, outcome);
+        double epsilon = 0.01;
+        if (x > 0.0 && y > 0.0 && std::abs(x - y) < epsilon)
+        {
+            linearVelocity = (x + y) / 2;
+        }
+        else
+        {
+        // we move either laterally or diagonally.
+        // if the first axis is pressed, we move laterally to the right
+        // if the second axis is pressed, we move laterally to the left
+        // if both axes are pressed, we set both lateral and linear velocities. If the first is higher the
+        // robot moves diagonally to the right, if the second is higher the robot moves diagonally to the left
+            if (x > y && x > 0.0)
+            {
+                lateralVelocity = deadzone(x);
+                if (y > 0.0)
+                {
+                    linearVelocity = deadzone(y);
+                }
+            }
+            else if (y > x && y > 0.0)
+            {
+                lateralVelocity = -deadzone(y);
+                if (x > 0.0)
+                {
+                    linearVelocity = deadzone(x);
+                }
+            }
+        }
+
+        sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
     }
-    else if(start > 0)
+    // buttons and others only if not type is not pedals
+    else if (m_joypadType != "pedals")
     {
-        yInfo() << "[updateModule] Start walking";
-        cmd.addString("startWalking");
-        m_rpcClientPort.write(cmd, outcome);
+
+        linearVelocity =  -deadzone(x);
+        lateralVelocity = -deadzone(y);
+        angularVeloctiy = -deadzone(z);
+
+
+        m_joypadController->getButton(m_prepareButton, prepare);
+        m_joypadController->getButton(m_startButton, start);
+        m_joypadController->getButton(m_stopButton, stop);
+        m_joypadController->getButton(m_pauseButton, pause);
+        m_joypadController->getButton(m_connectGoalButton, connectGoal);
+        m_joypadController->getButton(m_connectRpcButton, connectRpc);
+        m_joypadController->getButton(m_disconnectButton, disconnect);
+
+        if (prepare > 0)
+        {
+            yInfo() << "[updateModule] Prepare robot";
+            cmd.addString("prepareRobot");
+            m_rpcClientPort.write(cmd, outcome);
+        }
+        else if (start > 0)
+        {
+            yInfo() << "[updateModule] Start walking";
+            cmd.addString("startWalking");
+            m_rpcClientPort.write(cmd, outcome);
+        }
+        else if (pause > 0)
+        {
+            yInfo() << "[updateModule] Pause walking";
+            cmd.addString("pauseWalking");
+            m_rpcClientPort.write(cmd, outcome);
+        }
+        else if (stop > 0)
+        {
+            yInfo() << "[updateModule] Stop walking";
+            cmd.addString("stopWalking");
+            m_rpcClientPort.write(cmd, outcome);
+        }
+        // connect the ports
+        else if (connectGoal > 0 && connectRpc > 0)
+        {
+            yInfo() << "[updateModule] Connecting both ports";
+            if (!yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
+                yarp::os::Network::connect(m_rpcClientPortName, m_rpcServerPortName);
+            if (!yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
+                yarp::os::Network::connect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
+        }
+        else if (m_connectPortsSeparately && connectGoal > 0)
+        {
+            yInfo() << "[updateModule] Connecting goal port";
+            if (!yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
+                yarp::os::Network::connect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
+        }
+        else if (m_connectPortsSeparately && connectRpc > 0)
+        {
+            yInfo() << "[updateModule] Connecting RPC port";
+            if (!yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
+                yarp::os::Network::connect(m_rpcClientPortName, m_rpcServerPortName);
+        }
+        // disconnect the ports
+        else if (disconnect > 0)
+        {
+            yInfo() << "[updateModule] Disconnecting ports";
+            if (yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
+                yarp::os::Network::disconnect(m_rpcClientPortName, m_rpcServerPortName);
+            if (yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
+                yarp::os::Network::disconnect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
+        }
+        else
+        {
+           sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
+        }
     }
-    else if(pause > 0)
-    {
-        yInfo() << "[updateModule] Pause walking";
-        cmd.addString("pauseWalking");
-        m_rpcClientPort.write(cmd, outcome);
-    }
-    else if(stop > 0)
-    {
-        yInfo() << "[updateModule] Stop walking";
-        cmd.addString("stopWalking");
-        m_rpcClientPort.write(cmd, outcome);
-    }
-    // connect the ports
-    else if (connectGoal > 0 && connectRpc > 0)
-    {
-        yInfo() << "[updateModule] Connecting both ports";
-        if (!yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
-            yarp::os::Network::connect(m_rpcClientPortName, m_rpcServerPortName);
-        if (!yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
-            yarp::os::Network::connect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
-    }
-    else if (m_connectPortsSeparately && connectGoal > 0)
-    {
-        yInfo() << "[updateModule] Connecting goal port";
-        if (!yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
-            yarp::os::Network::connect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
-    }
-    else if (m_connectPortsSeparately && connectRpc > 0)
-    {
-        yInfo() << "[updateModule] Connecting RPC port";
-        if (!yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
-            yarp::os::Network::connect(m_rpcClientPortName, m_rpcServerPortName);
-    }
-    // disconnect the ports
-    else if (disconnect > 0)
-    {
-        yInfo() << "[updateModule] Disconnecting ports";
-        if (yarp::os::Network::isConnected(m_rpcClientPortName, m_rpcServerPortName))
-            yarp::os::Network::disconnect(m_rpcClientPortName, m_rpcServerPortName);
-        if (yarp::os::Network::isConnected(m_robotGoalOutputPortName, m_robotGoalInputPortName))
-            yarp::os::Network::disconnect(m_robotGoalOutputPortName, m_robotGoalInputPortName);
-    }
-    else
-    {
-        yarp::sig::Vector& goal= m_robotGoalPort.prepare();
-        goal.clear();
-        goal.push_back(x);
-        goal.push_back(y);
-        goal.push_back(z);
-        m_robotGoalPort.write();
-    }
+
     return true;
 }
 
@@ -244,13 +290,25 @@ double JoypadModule::deadzone(const double &input)
     if (input >= 0)
     {
         if (input > m_deadzone)
-            return (input - m_deadzone)/(m_fullscale - m_deadzone);
-        else return 0.0;
+            return (input - m_deadzone) / (m_fullscale - m_deadzone);
+        else
+            return 0.0;
     }
     else
     {
         if (input < -m_deadzone)
-            return (input + m_deadzone)/(m_fullscale - m_deadzone);
-        else return 0.0;
+            return (input + m_deadzone) / (m_fullscale - m_deadzone);
+        else
+            return 0.0;
     }
+}
+
+void JoypadModule::sendGoal(const double linearVelocity, const double angularVelocity, const double lateralVelocity)
+{
+    yarp::sig::Vector &goal = m_robotGoalPort.prepare();
+    goal.clear();
+    goal.push_back(linearVelocity);
+    goal.push_back(angularVelocity);
+    goal.push_back(lateralVelocity);
+    m_robotGoalPort.write();
 }

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -165,9 +165,7 @@ bool JoypadModule::close()
 }
 
 bool JoypadModule::updateModule()
-    m_joypadController->getAxis(m_forwardAxis, y);
-    m_joypadController->getAxis(rotationAxis, x);
-    m_joypadController->getAxis(sideAxis, z);
+{
         stop{0.0}, pause{0.0},
         connectGoal{0.0}, connectRpc{0.0}, disconnect{0.0};
 

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -169,8 +169,6 @@ bool JoypadModule::updateModule()
     m_joypadController->getAxis(1, x);
     m_joypadController->getAxis(2, z);
 
-    angularVeloctiy = deadzone(z);
-
     if (m_joypadType == "pedals")
     {
         double epsilon = 0.01;
@@ -180,11 +178,11 @@ bool JoypadModule::updateModule()
         }
         else
         {
-        // we move either laterally or diagonally.
-        // if the first axis is pressed, we move laterally to the right
-        // if the second axis is pressed, we move laterally to the left
-        // if both axes are pressed, we set both lateral and linear velocities. If the first is higher the
-        // robot moves diagonally to the right, if the second is higher the robot moves diagonally to the left
+            // we move either laterally or diagonally.
+            // if the first axis is pressed, we move laterally to the right
+            // if the second axis is pressed, we move laterally to the left
+            // if both axes are pressed, we set both lateral and linear velocities. If the first is higher the
+            // robot moves diagonally to the right, if the second is higher the robot moves diagonally to the left
             if (x > y && x > 0.0)
             {
                 lateralVelocity = deadzone(x);
@@ -202,17 +200,16 @@ bool JoypadModule::updateModule()
                 }
             }
         }
-
+        angularVeloctiy = deadzone(z);
         sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
     }
     // buttons and others only if not type is not pedals
     else if (m_joypadType != "pedals")
     {
 
-        linearVelocity =  -deadzone(x);
+        linearVelocity = -deadzone(x);
         lateralVelocity = -deadzone(y);
         angularVeloctiy = -deadzone(z);
-
 
         m_joypadController->getButton(m_prepareButton, prepare);
         m_joypadController->getButton(m_startButton, start);
@@ -278,7 +275,11 @@ bool JoypadModule::updateModule()
         }
         else
         {
-           sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
+
+            linearVelocity = -deadzone(x);
+            angularVeloctiy = -deadzone(y);
+            lateralVelocity = -deadzone(z);
+            sendGoal(linearVelocity, angularVeloctiy, lateralVelocity);
         }
     }
 

--- a/src/JoypadModule/src/Module.cpp
+++ b/src/JoypadModule/src/Module.cpp
@@ -71,7 +71,7 @@ bool JoypadModule::configure(yarp::os::ResourceFinder &rf)
                                                                {"disconnectButton", m_disconnectButton}};
     for (auto &input : joypadInputs)
     {
-        if (!YarpUtilities::getNumberFromSearchable(rf, input.first, input.second))
+        if (!YarpUtilities::getNumberFromSearchable(rf, input.first, input.second) && m_joypadType != "pedals")
         {
             yError() << "[configure] Unable to get " << input.first << " from searchable";
             return false;


### PR DESCRIPTION
The pedals only provide 3 axis values and no buttons. I replicate the results obtained with TT robots on the main `WalkingJoypadModule`. In essence;
- To command the linear velocity, one needs to press both pedals equally.
- To command lateral Velocity, one needs to press one more than the other with the pressed one corresponding to the desired direction :warning: this also allows diagonal commands!
- To command the angular velocity one needs to push one pedals forward with the pushed pedal corresponding to the desired rotation direction



:warning: I need to test with the robot and also to check if I didn't break the other options (gamepad and keypoard). In theory It should be ok.