### PR TITLE
Bump minimum CMake version for tests to 3.10

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set (CMAKE_CXX_STANDARD 11)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set (CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
I have installed the `robotology-superbuild` following [this readme](https://github.com/robotology/robotology-superbuild/blob/master/doc/conda-forge.md#source-installation).
Therefore, when installing the conda dependecies, I installed a recent version of CMake, which is `4.0.0`.

This cmake version, as per what stated in [the official documentation](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html), is no more compatible with cmake versions older than `3.5`:

> Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce an error in CMake 4.0 and above.

This PR aims at fixing compilation issues, when compiling with CMake 4.0.0, by bumping the minimum requirement from `3.1` to `3.10` for `walking-controllers/tests`.
