### PR TITLE
Remove version constraint for Eigen3 package for Eigen3 5.0.0 compat

### DIFF
--- a/cmake/WalkingControllersDependencies.cmake
+++ b/cmake/WalkingControllersDependencies.cmake
@@ -6,7 +6,7 @@ find_package(YARP 3.6.0 REQUIRED)
 find_package(ICUB REQUIRED)
 find_package(ICUBcontrib REQUIRED)
 find_package(iDynTree 10.0.0 REQUIRED)
-find_package(Eigen3 3.2.92 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(UnicyclePlanner 0.8.0 REQUIRED)
 find_package(OsqpEigen 0.4.0 REQUIRED)
 find_package(BipedalLocomotionFramework 0.18.0


### PR DESCRIPTION
Without this fix, configuration against Eigen 5 fails with:

~~~
CMake Error at cmake/OsqpEigenDependencies.cmake:14 (find_package):
  Could not find a configuration file for package "Eigen3" that is compatible
  with requested version "3.2.92".

  The following configuration files were considered but not accepted:

    /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0

Call Stack (most recent call first):
~~~

see https://gitlab.com/libeigen/eigen/-/issues/2972 for more details. As Eigen 3.3 was released in 2016, I think we are fine in just asking for Eigen without checking the version of it.

xref: https://github.com/conda-forge/eigen-feedstock/pull/47
xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/pull/1903